### PR TITLE
Make job history parser public

### DIFF
--- a/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/JobConfigurationParser.java
+++ b/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/JobConfigurationParser.java
@@ -51,7 +51,7 @@ public class JobConfigurationParser {
    *         configuration xml.
    * @throws IOException
    */
-  static Properties parse(InputStream input) throws IOException {
+  public static Properties parse(InputStream input) throws IOException {
     Properties result = new Properties();
 
     try {

--- a/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/ParsedJob.java
+++ b/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/ParsedJob.java
@@ -158,7 +158,7 @@ public class ParsedJob extends LoggedJob {
   }
 
   /** Dump the extra info of ParsedJob */
-  void dumpParsedJob() {
+  public void dumpParsedJob() {
     LOG.info("ParsedJob details:" + obtainTotalCounters() + ";"
         + obtainMapCounters() + ";" + obtainReduceCounters()
         + "\n" + obtainJobConfpath() + "\n" + obtainJobAcls()

--- a/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/ParsedTask.java
+++ b/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/ParsedTask.java
@@ -115,7 +115,7 @@ public class ParsedTask extends LoggedTask {
   }
 
   /** Dump the extra info of ParsedTask */
-  void dumpParsedTask() {
+  public void dumpParsedTask() {
     LOG.info("ParsedTask details:" + obtainCounters()
         + "\n" + obtainFailedDueToAttemptId()
         + "\nPreferred Locations are:");

--- a/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/ParsedTaskAttempt.java
+++ b/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/ParsedTaskAttempt.java
@@ -109,7 +109,7 @@ public class ParsedTaskAttempt extends LoggedTaskAttempt {
   }
 
   /** Dump the extra info of ParsedTaskAttempt */
-  void dumpParsedTaskAttempt() {
+  public void dumpParsedTaskAttempt() {
     LOG.info("ParsedTaskAttempt details:" + obtainCounters()
         + ";DiagnosticInfo=" + obtainDiagnosticInfo() + "\n"
         + obtainTrackerName() + ";" + obtainHttpPort() + ";"


### PR DESCRIPTION
It permits to reuse job history parser from a hadoop job
