### PR TITLE
YARN-3227. Timeline renew delegation token fails when RM user's TGT is expired. 

### DIFF
--- a/hadoop-yarn-project/CHANGES.txt
+++ b/hadoop-yarn-project/CHANGES.txt
@@ -6,6 +6,9 @@ Release 2.6.0 - 2014-11-18
 
   NEW FEATURES
 
+    YARN-3227. Timeline renew delegation token fails when RM user's TGT is expired
+    (Zhijie Shen via xgong)
+
     YARN-3700. Made generic history service load a number of latest applications
     according to the parameter or the configuration. (Xuan Gong via zjshen)
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineClientImpl.java
@@ -445,6 +445,7 @@ public class TimelineClientImpl extends TimelineClient {
         UserGroupInformation callerUGI = isProxyAccess ?
             UserGroupInformation.getCurrentUser().getRealUser()
             : UserGroupInformation.getCurrentUser();
+        callerUGI.checkTGTAndReloginFromKeytab();
         try {
           return callerUGI.doAs(action);
         } catch (UndeclaredThrowableException e) {
@@ -494,6 +495,7 @@ public class TimelineClientImpl extends TimelineClient {
           : UserGroupInformation.getCurrentUser();
       final String doAsUser = isProxyAccess ?
           UserGroupInformation.getCurrentUser().getShortUserName() : null;
+      callerUGI.checkTGTAndReloginFromKeytab();
       try {
         return callerUGI.doAs(new PrivilegedExceptionAction<HttpURLConnection>() {
           @Override


### PR DESCRIPTION
Contributed by Zhijie Shen

(cherry picked from commit d1abc5d4fc00bb1b226066684556ba16ace71744)
(cherry picked from commit 56c2050ab7c04e9741bcba9504b71e5a54d09eea)
(cherry picked from commit 780a9b1a98827a692e0ea9fbc92f9d1ab979e3e0)
