### PR TITLE
Backport HDFS-9555 to avoid spamming logs with LazyPersistFileScrubber exception

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/CHANGES.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs/CHANGES.txt
@@ -14,6 +14,9 @@ Release 2.6.0 - 2014-11-18
 
   IMPROVEMENTS
 
+    HDFS-9555. LazyPersistFileScrubber should still sleep if there are errors
+    in the clear progress (Phil Yang via kihwal)
+
     HDFS-7213. processIncrementalBlockReport performance degradation.
 
     HDFS-8581. ContentSummary on / skips further counts on yielding lock

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -5368,14 +5368,17 @@ public class FSNamesystem implements Namesystem, FSClusterStats,
       while (fsRunning && shouldRun) {
         try {
           clearCorruptLazyPersistFiles();
+        } catch (Exception e) {
+          FSNamesystem.LOG.error(
+              "Ignoring exception in LazyPersistFileScrubber:", e);
+        }
+
+        try {
           Thread.sleep(scrubIntervalSec * 1000);
         } catch (InterruptedException e) {
           FSNamesystem.LOG.info(
               "LazyPersistFileScrubber was interrupted, exiting");
           break;
-        } catch (Exception e) {
-          FSNamesystem.LOG.error(
-              "Ignoring exception in LazyPersistFileScrubber:", e);
         }
       }
     }


### PR DESCRIPTION
Due to LazyPersistFileScrubber not sleeping in case of error we have generated a quite huge log files with 17427909 lines of ERROR org.apache.hadoop.hdfs.server.namenode.FSNamesystem: Ignoring exception in LazyPersistFileScrubber
This patch will ensure the sleep (5 min by default) limiting the number of times we display this issue and also limiting the number of times we call the clearCorruptLazyPersistFiles method