### PR TITLE
YARN-4611. Fix scheduler load simulator to support multi-layer network

### DIFF
--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/utils/SLSUtils.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/utils/SLSUtils.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.net.NodeBase;
 import org.apache.hadoop.tools.rumen.JobTraceReader;
 import org.apache.hadoop.tools.rumen.LoggedJob;
 import org.apache.hadoop.tools.rumen.LoggedTask;
@@ -42,9 +43,15 @@ import java.util.Iterator;
 @Unstable
 public class SLSUtils {
 
+  // hostname includes the network path and the host name. for example
+  // "/default-rack/hostFoo" or "/coreSwitchA/TORSwitchB/hostBar".
+  // the function returns two Strings, the first element is the network
+  // location without "/", the second element is the host name. for example,
+  // {"default-rack", "hostFoo"} or "coreSwitchA/TORSwitchB", "hostBar"
   public static String[] getRackHostName(String hostname) {
-    hostname = hostname.substring(1);
-    return hostname.split("/");
+    NodeBase node = new NodeBase(hostname);
+    return new String[] {node.getNetworkLocation().substring(1),
+        node.getName()};
   }
 
   /**

--- a/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/nodemanager/TestNMSimulator.java
+++ b/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/nodemanager/TestNMSimulator.java
@@ -51,7 +51,7 @@ public class TestNMSimulator {
   public void testNMSimulator() throws Exception {
     // Register one node
     NMSimulator node1 = new NMSimulator();
-    node1.init("rack1/node1", GB * 10, 10, 0, 1000, rm);
+    node1.init("/rack1/node1", GB * 10, 10, 0, 1000, rm);
     node1.middleStep();
 
     int numClusterNodes = rm.getResourceScheduler().getNumClusterNodes();

--- a/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/utils/TestSLSUtils.java
+++ b/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/utils/TestSLSUtils.java
@@ -29,6 +29,11 @@ public class TestSLSUtils {
     String rackHostname[] = SLSUtils.getRackHostName(str);
     Assert.assertEquals(rackHostname[0], "rack1");
     Assert.assertEquals(rackHostname[1], "node1");
+
+    str = "/rackA/rackB/node1";
+    rackHostname = SLSUtils.getRackHostName(str);
+    Assert.assertEquals(rackHostname[0], "rackA/rackB");
+    Assert.assertEquals(rackHostname[1], "node1");
   }
 
 }

--- a/hadoop-yarn-project/CHANGES.txt
+++ b/hadoop-yarn-project/CHANGES.txt
@@ -394,6 +394,9 @@ Release 2.6.0 - 2014-11-18
 
   BUG FIXES
 
+    YARN-4611. Fix scheduler load simulator to support multi-layer network
+    location. (Ming Ma via xgong)
+
     YARN-2251. Avoid negative elapsed time in JHS/MRAM web UI and services.
     (Zhijie Shen via junping_du)
 


### PR DESCRIPTION
YARN-4611. Fix scheduler load simulator to support multi-layer network
location. Contributed by Ming Ma.

(cherry picked from commit 1708a4cd2377c56e2cb5738720b7eaf10baf13c8)