### PR TITLE
HADOOP-14253: Rumen: TraceBuilder should treat configuration before

### DIFF
--- a/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/HistoryLogsComparator.java
+++ b/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/HistoryLogsComparator.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.tools.rumen;
+
+import org.apache.hadoop.fs.FileStatus;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+public class HistoryLogsComparator implements Comparator<FileStatus>, Serializable {
+  /**
+   * Compare the history file names, not the full paths.
+   * Job history file name format is such that doing lexicographic sort on the
+   * history file names should result in the order of jobs' submission times.
+   */
+
+  @Override
+  public int compare(FileStatus file1, FileStatus file2) {
+    String jobId1 = JobHistoryUtils.extractJobID(file1.getPath().getName());
+    if (jobId1 != null && jobId1.equals(JobHistoryUtils.extractJobID(file2.getPath().getName()))) {
+      if (JobHistoryUtils.isJobConfXml(file1.getPath().getName())) {
+        if (!JobHistoryUtils.isJobConfXml(file2.getPath().getName())) {
+          return -1;
+        }
+      } else if (JobHistoryUtils.isJobConfXml(file2.getPath().getName())) {
+        return +1;
+      }
+    }
+    return genericCompare(file1, file2);
+  }
+
+  private int genericCompare(FileStatus file1, FileStatus file2) {
+    return file1.getPath().getName().compareTo(file2.getPath().getName());
+  }
+
+
+}

--- a/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/TraceBuilder.java
+++ b/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/TraceBuilder.java
@@ -20,15 +20,11 @@ package org.apache.hadoop.tools.rumen;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -41,7 +37,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.mapreduce.jobhistory.HistoryEvent;
-import org.apache.hadoop.mapreduce.v2.hs.JobHistory;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 
@@ -90,20 +85,6 @@ public class TraceBuilder extends Configured implements Tool {
       for (int i = 2 + switchTop; i < args.length; ++i) {
         inputs.addAll(processInputArgument(
             args[i], conf, doRecursiveTraversal));
-      }
-    }
-
-    /**
-     * Compare the history file names, not the full paths.
-     * Job history file name format is such that doing lexicographic sort on the
-     * history file names should result in the order of jobs' submission times.
-     */
-    private static class HistoryLogsComparator
-        implements Comparator<FileStatus>, Serializable {
-      @Override
-      public int compare(FileStatus file1, FileStatus file2) {
-        return file1.getPath().getName().compareTo(
-                   file2.getPath().getName());
       }
     }
 

--- a/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestHistoryLogsComparator.java
+++ b/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestHistoryLogsComparator.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.tools.rumen;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestHistoryLogsComparator {
+
+  @Test
+  public void testCompareTwoCommonFile(){
+    FileStatus file1 = new FileStatus();
+    file1.setPath(new Path("/dir1/file1"));
+    FileStatus file2 = new FileStatus();
+    file2.setPath(new Path("/dir1/file2"));
+    FileStatus file3 = new FileStatus();
+    file3.setPath(new Path("/dir2/file1"));
+
+    HistoryLogsComparator comparator = new HistoryLogsComparator();
+
+    Assert.assertTrue(comparator.compare(file1, file2) <0);
+    Assert.assertTrue(comparator.compare(file2, file1) >0);
+    Assert.assertTrue(comparator.compare(file3, file2) <0);
+    Assert.assertTrue(comparator.compare(file2, file3) >0);
+    Assert.assertTrue(comparator.compare(file1, file3) == 0);
+    Assert.assertTrue(comparator.compare(file3, file1) == 0);
+  }
+
+  @Test
+  public void testCompareOnFileForTheSameJobShouldGiveConfFileAsLowerFile(){
+    FileStatus file1 = new FileStatus();
+    file1.setPath(new Path("/dir1/job_1488896259152_410442_conf.xml"));
+    FileStatus file2 = new FileStatus();
+    file2.setPath(new Path("/dir1/job_1488896259152_410442-description.jhist"));
+
+    HistoryLogsComparator comparator = new HistoryLogsComparator();
+
+    Assert.assertTrue(comparator.compare(file1, file2) <0);
+    Assert.assertTrue(comparator.compare(file2, file1) >0);
+  }
+
+}


### PR DESCRIPTION
HADOOP-14253: Rumen: TraceBuilder should treat configuration beforeistory

Warning: patch not yet accepted