### PR TITLE
HADOOP-12054. RPC client should not retry for InvalidToken exceptions (Contributed by Varun Saxena)

### DIFF
--- a/hadoop-common-project/hadoop-common/CHANGES.txt
+++ b/hadoop-common-project/hadoop-common/CHANGES.txt
@@ -16,6 +16,9 @@ Release 2.6.0 - 2014-11-18
 
   IMPROVEMENTS
 
+    HADOOP-12054. RPC client should not retry for InvalidToken exceptions.
+    (Varun Saxena via Arpit Agarwal)
+
     HADOOP-10808. Remove unused native code for munlock. (cnauroth)
 
     HADOOP-10815. Implement Windows equivalent of mlock. (cnauroth)

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryPolicies.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryPolicies.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.net.ConnectTimeoutException;
+import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 
 /**
  * <p>
@@ -581,6 +582,9 @@ public class RetryPolicies {
         // RetriableException or RetriableException wrapped 
         return new RetryAction(RetryAction.RetryDecision.RETRY,
               getFailoverOrRetrySleepTime(retries));
+      } else if (e instanceof InvalidToken) {
+        return new RetryAction(RetryAction.RetryDecision.FAIL, 0,
+            "Invalid or Cancelled Token");
       } else if (e instanceof SocketException
           || (e instanceof IOException && !(e instanceof RemoteException))) {
         if (isIdempotentOrAtMostOnce) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
@@ -62,6 +62,9 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.retry.DefaultFailoverProxyProvider;
+import org.apache.hadoop.io.retry.FailoverProxyProvider;
+import org.apache.hadoop.io.retry.Idempotent;
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.ipc.Client.ConnectionId;
@@ -71,6 +74,7 @@ import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto;
 import org.apache.hadoop.net.ConnectTimeoutException;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.log4j.Level;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -204,18 +208,21 @@ public class TestIPC {
       this.server = server;
       this.total = total;
     }
-    
+
+    protected Object returnValue(Object value) throws Exception {
+      if (retry++ < total) {
+        throw new IOException("Fake IOException");
+      }
+      return value;
+    }
+
     @Override
     public Object invoke(Object proxy, Method method, Object[] args)
         throws Throwable {
       LongWritable param = new LongWritable(RANDOM.nextLong());
       LongWritable value = (LongWritable) client.call(param,
           NetUtils.getConnectAddress(server), null, null, 0, conf);
-      if (retry++ < total) {
-        throw new IOException("Fake IOException");
-      } else {
-        return value;
-      }
+      return returnValue(value);
     }
 
     @Override
@@ -226,7 +233,26 @@ public class TestIPC {
       return null;
     }
   }
-  
+
+  private static class TestInvalidTokenHandler extends TestInvocationHandler {
+    private int invocations = 0;
+    TestInvalidTokenHandler(Client client, Server server) {
+      super(client, server, 1);
+    }
+
+    @Override
+    protected Object returnValue(Object value) throws Exception {
+      throw new InvalidToken("Invalid Token");
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args)
+        throws Throwable {
+      invocations++;
+      return super.invoke(proxy, method, args);
+    }
+  }
+
   @Test(timeout=60000)
   public void testSerial() throws Exception {
     internalTestSerial(3, false, 2, 5, 100);
@@ -1025,7 +1051,8 @@ public class TestIPC {
   
   /** A dummy protocol */
   private interface DummyProtocol {
-    public void dummyRun();
+    @Idempotent
+    public void dummyRun() throws IOException;
   }
   
   /**
@@ -1064,7 +1091,40 @@ public class TestIPC {
       server.stop();
     }
   }
-  
+
+  /**
+   * Test that there is no retry when invalid token exception is thrown.
+   * Verfies fix for HADOOP-12054
+   */
+  @Test(expected = InvalidToken.class)
+  public void testNoRetryOnInvalidToken() throws IOException {
+    final Client client = new Client(LongWritable.class, conf);
+    final TestServer server = new TestServer(1, false);
+    TestInvalidTokenHandler handler =
+        new TestInvalidTokenHandler(client, server);
+    DummyProtocol proxy = (DummyProtocol) Proxy.newProxyInstance(
+        DummyProtocol.class.getClassLoader(),
+        new Class[] { DummyProtocol.class }, handler);
+    FailoverProxyProvider<DummyProtocol> provider =
+        new DefaultFailoverProxyProvider<DummyProtocol>(
+            DummyProtocol.class, proxy);
+    DummyProtocol retryProxy =
+        (DummyProtocol) RetryProxy.create(DummyProtocol.class, provider,
+        RetryPolicies.failoverOnNetworkException(
+            RetryPolicies.TRY_ONCE_THEN_FAIL, 100, 100, 10000, 0));
+
+    try {
+      server.start();
+      retryProxy.dummyRun();
+    } finally {
+      // Check if dummyRun called only once
+      Assert.assertEquals(handler.invocations, 1);
+      Client.setCallIdAndRetryCount(0, 0);
+      client.stop();
+      server.stop();
+    }
+  }
+
   /**
    * Test if the rpc server gets the default retry count (0) from client.
    */


### PR DESCRIPTION
This has overload the namenode with thousands of new connections for a lease
that can't be taken has the token was expeired or not in cache.
The idea of this patch is to not retry if the issue is due to token expired or not in cache

Here are some logs showing the issue
```
2017-03-02 11:51:42,817 INFO SecurityLogger.org.apache.hadoop.security.authorize.ServiceAuthorizationManager: Authorization successful for appattempt_1488396860014_156103_000001 (auth:TOKEN) for protocol=interface org.apache.hadoop.yarn.api.ContainerManagementProtocolPB
  2017-03-02 11:51:43,414 INFO SecurityLogger.org.apache.hadoop.security.authorize.ServiceAuthorizationManager: Authorization successful for appattempt_1488396860014_156120_000001 (auth:TOKEN) for protocol=interface org.apache.hadoop.yarn.api.ContainerManagementProtocolPB
  2017-03-02 11:51:51,994 WARN org.apache.hadoop.security.UserGroupInformation: PriviledgedActionException as:prediction (auth:SIMPLE) cause:org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.token.SecretManager$InvalidToken): token (HDFS_DELEGATION_TOKEN token 111018676 for prediction) is expired
  2017-03-02 11:51:51,995 WARN org.apache.hadoop.ipc.Client: Exception encountered while connecting to the server : org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.token.SecretManager$InvalidToken): token (HDFS_DELEGATION_TOKEN token 111018676 for prediction) is expired
  2017-03-02 11:51:51,995 WARN org.apache.hadoop.security.UserGroupInformation: PriviledgedActionException as:prediction (auth:SIMPLE) cause:org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.token.SecretManager$InvalidToken): token (HDFS_DELEGATION_TOKEN token 111018676 for prediction) is expired
  2017-03-02 11:51:51,995 WARN org.apache.hadoop.hdfs.LeaseRenewer: Failed to renew lease for [DFSClient_NONMAPREDUCE_1560141256_4187204] for 30 seconds.  Will retry shortly ...
  token (HDFS_DELEGATION_TOKEN token 111018676 for prediction) is expired
     at org.apache.hadoop.ipc.Client.call(Client.java:1472)
     at org.apache.hadoop.ipc.Client.call(Client.java:1403)
     at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:230)
     at com.sun.proxy.$Proxy20.renewLease(Unknown Source)
     at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.renewLease(ClientNamenodeProtocolTranslatorPB.java:571)
     at sun.reflect.GeneratedMethodAccessor74.invoke(Unknown Source)
     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
     at java.lang.reflect.Method.invoke(Method.java:498)
     at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:252)
     at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:104)
     at com.sun.proxy.$Proxy21.renewLease(Unknown Source)
     at org.apache.hadoop.hdfs.DFSClient.renewLease(DFSClient.java:921)
     at org.apache.hadoop.hdfs.LeaseRenewer.renew(LeaseRenewer.java:423)
     at org.apache.hadoop.hdfs.LeaseRenewer.run(LeaseRenewer.java:448)
     at org.apache.hadoop.hdfs.LeaseRenewer.access$700(LeaseRenewer.java:71)
     at org.apache.hadoop.hdfs.LeaseRenewer$1.run(LeaseRenewer.java:304)
     at java.lang.Thread.run(Thread.java:745)


  2017-03-02 12:51:22,032 WARN org.apache.hadoop.security.UserGroupInformation: PriviledgedActionException as:prediction (auth:SIMPLE) cause:org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.token.SecretManager$InvalidToken): token (HDFS_DELEGATION_TOKEN token 111018676 for prediction) can't be found in cache
  2017-03-02 12:51:22,032 WARN org.apache.hadoop.ipc.Client: Exception encountered while connecting to the server : org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.token.SecretManager$InvalidToken): token (HDFS_DELEGATION_TOKEN token 111018676 for prediction) can't be found in cache
  2017-03-02 12:51:22,033 WARN org.apache.hadoop.security.UserGroupInformation: PriviledgedActionException as:prediction (auth:SIMPLE) cause:org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.token.SecretManager$InvalidToken): token (HDFS_DELEGATION_TOKEN token 111018676 for prediction) can't be found in cache
  2017-03-02 12:51:22,033 WARN org.apache.hadoop.hdfs.DFSClient: Failed to renew lease for DFSClient_NONMAPREDUCE_1560141256_4187204 for 3600 seconds (>= hard-limit =3600 seconds.) Closing all files being written ...
  token (HDFS_DELEGATION_TOKEN token 111018676 for prediction) can't be found in cache
     at org.apache.hadoop.ipc.Client.call(Client.java:1472)
     at org.apache.hadoop.ipc.Client.call(Client.java:1403)
     at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:230)
     at com.sun.proxy.$Proxy20.renewLease(Unknown Source)
     at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.renewLease(ClientNamenodeProtocolTranslatorPB.java:571)
     at sun.reflect.GeneratedMethodAccessor74.invoke(Unknown Source)
     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
     at java.lang.reflect.Method.invoke(Method.java:498)
     at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:252)
     at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:104)
     at com.sun.proxy.$Proxy21.renewLease(Unknown Source)
     at org.apache.hadoop.hdfs.DFSClient.renewLease(DFSClient.java:921)
     at org.apache.hadoop.hdfs.LeaseRenewer.renew(LeaseRenewer.java:423)
     at org.apache.hadoop.hdfs.LeaseRenewer.run(LeaseRenewer.java:448)
     at org.apache.hadoop.hdfs.LeaseRenewer.access$700(LeaseRenewer.java:71)
     at org.apache.hadoop.hdfs.LeaseRenewer$1.run(LeaseRenewer.java:304)
     at java.lang.Thread.run(Thread.java:745)
  2017-03-02 12:51:27,364 WARN org.apache.hadoop.yarn.server.nodemanager.containermanager.logaggregation.AppLogAggregatorImpl: rollingMonitorInterval is set as -1. The log rolling mornitoring interval is disabled. The logs will be aggregated after this application is finished.
```

This patch globaly ensure that no retry is performed for invalidtoken exception