### PR TITLE
Backport YARN-3760 - FSDataOutputStream leak in AggregatedLogFormat.LogWriter.close()

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/AggregatedLogFormat.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/AggregatedLogFormat.java
@@ -452,10 +452,11 @@ public class AggregatedLogFormat {
     public void close() {
       try {
         this.writer.close();
-      } catch (IOException e) {
+      } catch (Exception e) {
         LOG.warn("Exception closing writer", e);
+      } finally {
+        IOUtils.closeStream(fsDataOStream);
       }
-      IOUtils.closeStream(fsDataOStream);
     }
   }
 


### PR DESCRIPTION
DDoS of namenode due to nodemanagers LeaseRenewer thread trying to renew a lease on a file not being
well closed. Then we start to face InvalidToken during an hour every second.