### PR TITLE
YARN-3585. NodeManager cannot exit on SHUTDOWN event triggered and NM recovery is enabled

### DIFF
--- a/hadoop-yarn-project/CHANGES.txt
+++ b/hadoop-yarn-project/CHANGES.txt
@@ -6,6 +6,9 @@ Release 2.6.0 - 2014-11-18
 
   NEW FEATURES
 
+    YARN-3585. NodeManager cannot exit on SHUTDOWN event triggered and NM
+    recovery is enabled (Rohith Sharmaks via jlowe)
+
     YARN-3287. Made TimelineClient put methods do as the correct login context.
     (Daryn Sharp and Jonathan Eagles via zjshen)
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeManager.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.service.CompositeService;
+import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.util.StringUtils;
@@ -90,6 +91,7 @@ public class NodeManager extends CompositeService
   
   private AtomicBoolean isStopping = new AtomicBoolean(false);
   private boolean rmWorkPreservingRestartEnabled;
+  private boolean shouldExitOnShutdownEvent = false;
 
   public NodeManager() {
     super(NodeManager.class.getName());
@@ -284,7 +286,16 @@ public class NodeManager extends CompositeService
     new Thread() {
       @Override
       public void run() {
-        NodeManager.this.stop();
+        try {
+          NodeManager.this.stop();
+        } catch (Throwable t) {
+          LOG.error("Error while shutting down NodeManager", t);
+        } finally {
+          if (shouldExitOnShutdownEvent
+              && !ShutdownHookManager.get().isShutdownInProgress()) {
+            ExitUtil.terminate(-1);
+          }
+        }
       }
     }.start();
   }
@@ -470,7 +481,9 @@ public class NodeManager extends CompositeService
       nodeManagerShutdownHook = new CompositeServiceShutdownHook(this);
       ShutdownHookManager.get().addShutdownHook(nodeManagerShutdownHook,
                                                 SHUTDOWN_HOOK_PRIORITY);
-
+      // System exit should be called only when NodeManager is instantiated from
+      // main() funtion
+      this.shouldExitOnShutdownEvent = true;
       this.init(conf);
       this.start();
     } catch (Throwable t) {


### PR DESCRIPTION
When decommissioning a nodemanagers we face below issue which cause it to not been shutdown.
Then if we recommission it doesn't come back and require a manual restart.
{code}
  2017-04-14 09:53:15,585 FATAL org.apache.hadoop.yarn.event.AsyncDispatcher: Error in dispatcher thread
  java.lang.InterruptedException
     at org.apache.hadoop.yarn.event.AsyncDispatcher$GenericEventHandler.handle(AsyncDispatcher.java:247)
     at org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.handleDestroyApplicationResources(ResourceLocalizationService.java:621)
     at org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.handle(ResourceLocalizationService.java:423)
     at org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.handle(ResourceLocalizationService.java:141)
     at org.apache.hadoop.yarn.event.AsyncDispatcher.dispatch(AsyncDispatcher.java:174)
     at org.apache.hadoop.yarn.event.AsyncDispatcher$1.run(AsyncDispatcher.java:106)
     at java.lang.Thread.run(Thread.java:745)
  by: java.lang.InterruptedException
     at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireInterruptibly(AbstractQueuedSynchronizer.java:1220)
     at java.util.concurrent.locks.ReentrantLock.lockInterruptibly(ReentrantLock.java:335)
     at java.util.concurrent.LinkedBlockingQueue.put(LinkedBlockingQueue.java:339)
     at org.apache.hadoop.yarn.event.AsyncDispatcher$GenericEventHandler.handle(AsyncDispatcher.java:242)
     ... 6 more
  2017-04-14 09:53:15,587 WARN org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor.ContainersMonitorImpl: org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor.ContainersMonitorImpl is interrupted. Exiting.
  2017-04-14 09:54:18,335 ERROR org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor: DeleteAsUser for /hdfs/uuid/2656bd19-ac15-46c9-8bde-019b8b08dc70/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/1f37278f-fff3-425b-a1fc-30d56a88b6db/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/f97f910c-cd0e-44bb-925f-3d5ff8be581f/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/edb119d5-1fbb-4bce-aab1-8fcc82635469/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/da5bb0e0-99df-49a1-9976-eed895235f3c/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/73a8ac91-0259-4db4-be41-5cd1b1d31ce6/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/8348823f-be46-4d0f-b726-037cd23305f8/yarn/logs/application_1491282033987_1661974 ...
  /hdfs/uuid/c9902862-4724-4828-9866-2896eb537173/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/456a9d59-c9e9-48c4-bb32-d19ccab2a584/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/2b618e51-19ff-48b9-9c70-5590f398d0a9/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/796f1e12-bb5d-4e4d-98e9-a283a65d6c46/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/8f7c5e16-7e52-4b16-af6c-d62c049d3e41/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/3efb506e-8885-4c14-86c8-1505cb53d2f8/yarn/logs/application_1491282033987_1661974 /hdfs/uuid/22cc545c-36e8-42e6-89a0-afaf0d104d74/yarn/logs/application_1491282033987_1661974 returned with exit code: 0
  java.lang.InterruptedException
     at org.apache.hadoop.util.Shell.runCommand(Shell.java:546)
     at org.apache.hadoop.util.Shell.run(Shell.java:460)
     at org.apache.hadoop.util.Shell$ShellCommandExecutor.execute(Shell.java:720)
     at org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor.deleteAsUser(LinuxContainerExecutor.java:520)
     at org.apache.hadoop.yarn.server.nodemanager.DeletionService$FileDeletionTask.run(DeletionService.java:295)
     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
     at java.util.concurrent.FutureTask.run(FutureTask.java:266)
     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
     at java.lang.Thread.run(Thread.java:745)
  2017-04-14 09:54:18,336 ERROR org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor: Output from LinuxContainerExecutor's deleteAsUser follows:
  2017-04-14 09:54:18,336 ERROR org.apache.hadoop.yarn.server.nodemanager.DeletionService: Unable to remove deletion task 190273 from state store
  org.iq80.leveldb.DBException: Closed
     at org.apache.hadoop.yarn.server.nodemanager.recovery.NMLeveldbStateStoreService.removeDeletionTask(NMLeveldbStateStoreService.java:678)
     at org.apache.hadoop.yarn.server.nodemanager.DeletionService$FileDeletionTask.fileDeletionTaskFinished(DeletionService.java:351)
     at org.apache.hadoop.yarn.server.nodemanager.DeletionService$FileDeletionTask.run(DeletionService.java:309)
     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
     at java.util.concurrent.FutureTask.run(FutureTask.java:266)
     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
     at java.lang.Thread.run(Thread.java:745)
  by: org.iq80.leveldb.DBException: Closed
     at org.fusesource.leveldbjni.internal.JniDB.delete(JniDB.java:135)
     at org.fusesource.leveldbjni.internal.JniDB.delete(JniDB.java:110)
     at org.apache.hadoop.yarn.server.nodemanager.recovery.NMLeveldbStateStoreService.removeDeletionTask(NMLeveldbStateStoreService.java:676)
     ... 9 more
{code}