### PR TITLE
HDFS-12292, HDFS-11432, HDFS-7600, HDFS-11177, HDFS-11011. Support viewfs:// schema path for DfsAdmin commands

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Command.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Command.java
@@ -100,7 +100,17 @@ abstract public class Command extends Configured {
    * @throws IOException if any error occurs
    */
   abstract protected void run(Path path) throws IOException;
-  
+
+  /**
+   * Execute the command on the input path data. Commands can override to make
+   * use of the resolved filesystem.
+   * @param pathData The input path with resolved filesystem
+   * @throws IOException
+   */
+  protected void run(PathData pathData) throws IOException {
+    run(pathData.path);
+  }
+
   /** 
    * For each source path, execute the command
    * 
@@ -112,7 +122,7 @@ abstract public class Command extends Configured {
       try {
         PathData[] srcs = PathData.expandAsGlob(src, getConf());
         for (PathData s : srcs) {
-          run(s.path);
+          run(s);
         }
       } catch (IOException e) {
         exitCode = -1;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/PathData.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/PathData.java
@@ -308,6 +308,29 @@ public class PathData implements Comparable<PathData> {
   protected enum PathType { HAS_SCHEME, SCHEMELESS_ABSOLUTE, RELATIVE };
   
   /**
+   * Resolves an actual file system for the given {@link PathData}
+   * through any symlinks or mount points.
+   * @param src {@link PathData} to be resolved
+   * @param conf the hadoop configuration
+   * @return new {@link PathData} if a fs changed, or the same object otherwise
+   * @throws FileNotFoundException when the path does not exist
+   * @throws IOException from #{@link FileSystem} implementations
+   */
+  public static PathData resolveFsPath(PathData src, Configuration conf)
+      throws IOException {
+    Path resolvedPath = src.fs.resolvePath(src.path);
+    if (resolvedPath.equals(src.path)) {
+      return src;
+    }
+    FileSystem resolvedFs = resolvedPath.getFileSystem(conf);
+    if (resolvedFs.equals(src.fs)) {
+      return src;
+    }
+    // FileStatus contains unresolved path in will be replaced too
+    return new PathData(resolvedFs, resolvedPath.toString());
+  }
+
+  /**
    * Expand the given path as a glob pattern.  Non-existent paths do not
    * throw an exception because creation commands like touch and mkdir need
    * to create them.  The "stat" field will be null if the path does not

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/AdminHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/AdminHelper.java
@@ -1,0 +1,203 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.tools;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdfs.DFSUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.protocol.CachePoolInfo;
+import org.apache.hadoop.tools.TableListing;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Helper methods for CacheAdmin/CryptoAdmin/StoragePolicyAdmin
+ */
+public class AdminHelper {
+  /**
+   * Maximum length for printed lines
+   */
+  static final int MAX_LINE_WIDTH = 80;
+  static final String HELP_COMMAND_NAME = "-help";
+
+  static DistributedFileSystem getDFS(Configuration conf)
+      throws IOException {
+    FileSystem fs = FileSystem.get(conf);
+    if (!(fs instanceof DistributedFileSystem)) {
+      throw new IllegalArgumentException("FileSystem " + fs.getUri() +
+          " is not an HDFS file system");
+    }
+    return (DistributedFileSystem)fs;
+  }
+
+  static DistributedFileSystem getDFS(URI uri, Configuration conf)
+      throws IOException {
+    FileSystem fs = FileSystem.get(uri, conf);
+    if (!(fs instanceof DistributedFileSystem)) {
+      throw new IllegalArgumentException("FileSystem " + fs.getUri()
+          + " is not an HDFS file system");
+    }
+    return (DistributedFileSystem) fs;
+  }
+
+  /**
+   * NN exceptions contain the stack trace as part of the exception message.
+   * When it's a known error, pretty-print the error and squish the stack trace.
+   */
+  static String prettifyException(Exception e) {
+    return e.getClass().getSimpleName() + ": "
+        + e.getLocalizedMessage().split("\n")[0];
+  }
+
+  static TableListing getOptionDescriptionListing() {
+    return new TableListing.Builder()
+        .addField("").addField("", true)
+        .wrapWidth(MAX_LINE_WIDTH).hideHeaders().build();
+  }
+
+  /**
+   * Parses a time-to-live value from a string
+   * @return The ttl in milliseconds
+   * @throws IOException if it could not be parsed
+   */
+  static Long parseTtlString(String maxTtlString) throws IOException {
+    Long maxTtl = null;
+    if (maxTtlString != null) {
+      if (maxTtlString.equalsIgnoreCase("never")) {
+        maxTtl = CachePoolInfo.RELATIVE_EXPIRY_NEVER;
+      } else {
+        maxTtl = DFSUtil.parseRelativeTime(maxTtlString);
+      }
+    }
+    return maxTtl;
+  }
+
+  static Long parseLimitString(String limitString) {
+    Long limit = null;
+    if (limitString != null) {
+      if (limitString.equalsIgnoreCase("unlimited")) {
+        limit = CachePoolInfo.LIMIT_UNLIMITED;
+      } else {
+        limit = Long.parseLong(limitString);
+      }
+    }
+    return limit;
+  }
+
+  static Command determineCommand(String commandName, Command[] commands) {
+    Preconditions.checkNotNull(commands);
+    if (HELP_COMMAND_NAME.equals(commandName)) {
+      return new HelpCommand(commands);
+    }
+    for (Command command : commands) {
+      if (command.getName().equals(commandName)) {
+        return command;
+      }
+    }
+    return null;
+  }
+
+  static void printUsage(boolean longUsage, String toolName,
+      Command[] commands) {
+    Preconditions.checkNotNull(commands);
+    System.err.println("Usage: bin/hdfs " + toolName + " [COMMAND]");
+    final HelpCommand helpCommand = new HelpCommand(commands);
+    for (AdminHelper.Command command : commands) {
+      if (longUsage) {
+        System.err.print(command.getLongUsage());
+      } else {
+        System.err.print("          " + command.getShortUsage());
+      }
+    }
+    System.err.print(longUsage ? helpCommand.getLongUsage() :
+        ("          " + helpCommand.getShortUsage()));
+    System.err.println();
+  }
+
+  interface Command {
+    String getName();
+    String getShortUsage();
+    String getLongUsage();
+    int run(Configuration conf, List<String> args) throws IOException;
+  }
+
+  static class HelpCommand implements Command {
+    private final Command[] commands;
+
+    public HelpCommand(Command[] commands) {
+      Preconditions.checkNotNull(commands != null);
+      this.commands = commands;
+    }
+
+    @Override
+    public String getName() {
+      return HELP_COMMAND_NAME;
+    }
+
+    @Override
+    public String getShortUsage() {
+      return "[-help <command-name>]\n";
+    }
+
+    @Override
+    public String getLongUsage() {
+      final TableListing listing = AdminHelper.getOptionDescriptionListing();
+      listing.addRow("<command-name>", "The command for which to get " +
+          "detailed help. If no command is specified, print detailed help for " +
+          "all commands");
+      return getShortUsage() + "\n" +
+          "Get detailed help about a command.\n\n" +
+          listing.toString();
+    }
+
+    @Override
+    public int run(Configuration conf, List<String> args) throws IOException {
+      if (args.size() == 0) {
+        for (AdminHelper.Command command : commands) {
+          System.err.println(command.getLongUsage());
+        }
+        return 0;
+      }
+      if (args.size() != 1) {
+        System.out.println("You must give exactly one argument to -help.");
+        return 0;
+      }
+      final String commandName = args.get(0);
+      // prepend a dash to match against the command names
+      final AdminHelper.Command command = AdminHelper
+          .determineCommand("-" + commandName, commands);
+      if (command == null) {
+        System.err.print("Unknown command '" + commandName + "'.\n");
+        System.err.print("Valid help command names are:\n");
+        String separator = "";
+        for (AdminHelper.Command c : commands) {
+          System.err.print(separator + c.getName().substring(1));
+          separator = ", ";
+        }
+        System.err.print("\n");
+        return 1;
+      }
+      System.err.print(command.getLongUsage());
+      return 0;
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/CacheAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/CacheAdmin.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.CacheFlag;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -53,11 +52,6 @@ import com.google.common.base.Joiner;
 @InterfaceAudience.Private
 public class CacheAdmin extends Configured implements Tool {
 
-  /**
-   * Maximum length for printed lines
-   */
-  private static final int MAX_LINE_WIDTH = 80;
-
   public CacheAdmin() {
     this(null);
   }
@@ -69,16 +63,17 @@ public class CacheAdmin extends Configured implements Tool {
   @Override
   public int run(String[] args) throws IOException {
     if (args.length == 0) {
-      printUsage(false);
+      AdminHelper.printUsage(false, "cacheadmin", COMMANDS);
       return 1;
     }
-    Command command = determineCommand(args[0]);
+    AdminHelper.Command command = AdminHelper.determineCommand(args[0],
+        COMMANDS);
     if (command == null) {
       System.err.println("Can't understand command '" + args[0] + "'");
       if (!args[0].startsWith("-")) {
         System.err.println("Command names must start with dashes.");
       }
-      printUsage(false);
+      AdminHelper.printUsage(false, "cacheadmin", COMMANDS);
       return 1;
     }
     List<String> argsList = new LinkedList<String>();
@@ -88,7 +83,7 @@ public class CacheAdmin extends Configured implements Tool {
     try {
       return command.run(getConf(), argsList);
     } catch (IllegalArgumentException e) {
-      System.err.println(prettifyException(e));
+      System.err.println(AdminHelper.prettifyException(e));
       return -1;
     }
   }
@@ -98,64 +93,9 @@ public class CacheAdmin extends Configured implements Tool {
     System.exit(cacheAdmin.run(argsArray));
   }
 
-  private static DistributedFileSystem getDFS(Configuration conf)
+  private static CacheDirectiveInfo.Expiration parseExpirationString(String ttlString)
       throws IOException {
-    FileSystem fs = FileSystem.get(conf);
-    if (!(fs instanceof DistributedFileSystem)) {
-      throw new IllegalArgumentException("FileSystem " + fs.getUri() + 
-      " is not an HDFS file system");
-    }
-    return (DistributedFileSystem)fs;
-  }
-
-  /**
-   * NN exceptions contain the stack trace as part of the exception message.
-   * When it's a known error, pretty-print the error and squish the stack trace.
-   */
-  private static String prettifyException(Exception e) {
-    return e.getClass().getSimpleName() + ": "
-        + e.getLocalizedMessage().split("\n")[0];
-  }
-
-  private static TableListing getOptionDescriptionListing() {
-    TableListing listing = new TableListing.Builder()
-    .addField("").addField("", true)
-    .wrapWidth(MAX_LINE_WIDTH).hideHeaders().build();
-    return listing;
-  }
-
-  /**
-   * Parses a time-to-live value from a string
-   * @return The ttl in milliseconds
-   * @throws IOException if it could not be parsed
-   */
-  private static Long parseTtlString(String maxTtlString) throws IOException {
-    Long maxTtl = null;
-    if (maxTtlString != null) {
-      if (maxTtlString.equalsIgnoreCase("never")) {
-        maxTtl = CachePoolInfo.RELATIVE_EXPIRY_NEVER;
-      } else {
-        maxTtl = DFSUtil.parseRelativeTime(maxTtlString);
-      }
-    }
-    return maxTtl;
-  }
-
-  private static Long parseLimitString(String limitString) {
-    Long limit = null;
-    if (limitString != null) {
-      if (limitString.equalsIgnoreCase("unlimited")) {
-        limit = CachePoolInfo.LIMIT_UNLIMITED;
-      } else {
-        limit = Long.parseLong(limitString);
-      }
-    }
-    return limit;
-  }
-
-  private static Expiration parseExpirationString(String ttlString)
-      throws IOException {
-    Expiration ex = null;
+    CacheDirectiveInfo.Expiration ex = null;
     if (ttlString != null) {
       if (ttlString.equalsIgnoreCase("never")) {
         ex = CacheDirectiveInfo.Expiration.NEVER;
@@ -167,14 +107,8 @@ public class CacheAdmin extends Configured implements Tool {
     return ex;
   }
 
-  interface Command {
-    String getName();
-    String getShortUsage();
-    String getLongUsage();
-    int run(Configuration conf, List<String> args) throws IOException;
-  }
-
-  private static class AddCacheDirectiveInfoCommand implements Command {
+  private static class AddCacheDirectiveInfoCommand
+      implements AdminHelper.Command {
     @Override
     public String getName() {
       return "-addDirective";
@@ -190,7 +124,7 @@ public class CacheAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      TableListing listing = getOptionDescriptionListing();
+      TableListing listing = AdminHelper.getOptionDescriptionListing();
       listing.addRow("<path>", "A path to cache. The path can be " +
           "a directory or a file.");
       listing.addRow("<pool-name>", "The pool to which the directive will be " +
@@ -252,7 +186,8 @@ public class CacheAdmin extends Configured implements Tool {
         return 1;
       }
         
-      DistributedFileSystem dfs = getDFS(conf);
+      DistributedFileSystem dfs =
+          AdminHelper.getDFS(new Path(path).toUri(), conf);
       CacheDirectiveInfo directive = builder.build();
       EnumSet<CacheFlag> flags = EnumSet.noneOf(CacheFlag.class);
       if (force) {
@@ -262,7 +197,7 @@ public class CacheAdmin extends Configured implements Tool {
         long id = dfs.addCacheDirective(directive, flags);
         System.out.println("Added cache directive " + id);
       } catch (IOException e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
 
@@ -270,7 +205,8 @@ public class CacheAdmin extends Configured implements Tool {
     }
   }
 
-  private static class RemoveCacheDirectiveInfoCommand implements Command {
+  private static class RemoveCacheDirectiveInfoCommand
+      implements AdminHelper.Command {
     @Override
     public String getName() {
       return "-removeDirective";
@@ -283,7 +219,7 @@ public class CacheAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      TableListing listing = getOptionDescriptionListing();
+      TableListing listing = AdminHelper.getOptionDescriptionListing();
       listing.addRow("<id>", "The id of the cache directive to remove.  " + 
         "You must have write permission on the pool of the " +
         "directive in order to remove it.  To see a list " +
@@ -318,19 +254,20 @@ public class CacheAdmin extends Configured implements Tool {
         System.err.println("Usage is " + getShortUsage());
         return 1;
       }
-      DistributedFileSystem dfs = getDFS(conf);
+      DistributedFileSystem dfs = AdminHelper.getDFS(conf);
       try {
         dfs.getClient().removeCacheDirective(id);
         System.out.println("Removed cached directive " + id);
       } catch (IOException e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
       return 0;
     }
   }
 
-  private static class ModifyCacheDirectiveInfoCommand implements Command {
+  private static class ModifyCacheDirectiveInfoCommand
+      implements AdminHelper.Command {
     @Override
     public String getName() {
       return "-modifyDirective";
@@ -345,7 +282,7 @@ public class CacheAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      TableListing listing = getOptionDescriptionListing();
+      TableListing listing = AdminHelper.getOptionDescriptionListing();
       listing.addRow("<id>", "The ID of the directive to modify (required)");
       listing.addRow("<path>", "A path to cache. The path can be " +
           "a directory or a file. (optional)");
@@ -415,7 +352,7 @@ public class CacheAdmin extends Configured implements Tool {
         System.err.println("No modifications were specified.");
         return 1;
       }
-      DistributedFileSystem dfs = getDFS(conf);
+      DistributedFileSystem dfs = AdminHelper.getDFS(conf);
       EnumSet<CacheFlag> flags = EnumSet.noneOf(CacheFlag.class);
       if (force) {
         flags.add(CacheFlag.FORCE);
@@ -424,14 +361,15 @@ public class CacheAdmin extends Configured implements Tool {
         dfs.modifyCacheDirective(builder.build(), flags);
         System.out.println("Modified cache directive " + idString);
       } catch (IOException e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
       return 0;
     }
   }
 
-  private static class RemoveCacheDirectiveInfosCommand implements Command {
+  private static class RemoveCacheDirectiveInfosCommand
+      implements AdminHelper.Command {
     @Override
     public String getName() {
       return "-removeDirectives";
@@ -444,7 +382,7 @@ public class CacheAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      TableListing listing = getOptionDescriptionListing();
+      TableListing listing = AdminHelper.getOptionDescriptionListing();
       listing.addRow("-path <path>", "The path of the cache directives to remove.  " +
         "You must have write permission on the pool of the directive in order " +
         "to remove it.  To see a list of cache directives, use the " +
@@ -468,7 +406,8 @@ public class CacheAdmin extends Configured implements Tool {
       }
       int exitCode = 0;
       try {
-        DistributedFileSystem dfs = getDFS(conf);
+        DistributedFileSystem dfs =
+            AdminHelper.getDFS(new Path(path).toUri(), conf);
         RemoteIterator<CacheDirectiveEntry> iter =
             dfs.listCacheDirectives(
                 new CacheDirectiveInfo.Builder().
@@ -480,12 +419,12 @@ public class CacheAdmin extends Configured implements Tool {
             System.out.println("Removed cache directive " +
                 entry.getInfo().getId());
           } catch (IOException e) {
-            System.err.println(prettifyException(e));
+            System.err.println(AdminHelper.prettifyException(e));
             exitCode = 2;
           }
         }
       } catch (IOException e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         exitCode = 2;
       }
       if (exitCode == 0) {
@@ -496,7 +435,8 @@ public class CacheAdmin extends Configured implements Tool {
     }
   }
 
-  private static class ListCacheDirectiveInfoCommand implements Command {
+  private static class ListCacheDirectiveInfoCommand
+      implements AdminHelper.Command {
     @Override
     public String getName() {
       return "-listDirectives";
@@ -510,7 +450,7 @@ public class CacheAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      TableListing listing = getOptionDescriptionListing();
+      TableListing listing = AdminHelper.getOptionDescriptionListing();
       listing.addRow("-stats", "List path-based cache directive statistics.");
       listing.addRow("<path>", "List only " +
           "cache directives with this path. " +
@@ -559,7 +499,7 @@ public class CacheAdmin extends Configured implements Tool {
       }
       TableListing tableListing = tableBuilder.build();
       try {
-        DistributedFileSystem dfs = getDFS(conf);
+        DistributedFileSystem dfs = AdminHelper.getDFS(conf);
         RemoteIterator<CacheDirectiveEntry> iter =
             dfs.listCacheDirectives(builder.build());
         int numEntries = 0;
@@ -596,14 +536,14 @@ public class CacheAdmin extends Configured implements Tool {
           System.out.print(tableListing);
         }
       } catch (IOException e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
       return 0;
     }
   }
 
-  private static class AddCachePoolCommand implements Command {
+  private static class AddCachePoolCommand implements AdminHelper.Command {
 
     private static final String NAME = "-addPool";
 
@@ -621,7 +561,7 @@ public class CacheAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      TableListing listing = getOptionDescriptionListing();
+      TableListing listing = AdminHelper.getOptionDescriptionListing();
 
       listing.addRow("<name>", "Name of the new pool.");
       listing.addRow("<owner>", "Username of the owner of the pool. " +
@@ -669,13 +609,13 @@ public class CacheAdmin extends Configured implements Tool {
         info.setMode(new FsPermission(mode));
       }
       String limitString = StringUtils.popOptionWithArgument("-limit", args);
-      Long limit = parseLimitString(limitString);
+      Long limit = AdminHelper.parseLimitString(limitString);
       if (limit != null) {
         info.setLimit(limit);
       }
       String maxTtlString = StringUtils.popOptionWithArgument("-maxTtl", args);
       try {
-        Long maxTtl = parseTtlString(maxTtlString);
+        Long maxTtl = AdminHelper.parseTtlString(maxTtlString);
         if (maxTtl != null) {
           info.setMaxRelativeExpiryMs(maxTtl);
         }
@@ -691,11 +631,11 @@ public class CacheAdmin extends Configured implements Tool {
         System.err.println("Usage is " + getShortUsage());
         return 1;
       }
-      DistributedFileSystem dfs = getDFS(conf);
+      DistributedFileSystem dfs = AdminHelper.getDFS(conf);
       try {
         dfs.addCachePool(info);
       } catch (IOException e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
       System.out.println("Successfully added cache pool " + name + ".");
@@ -703,7 +643,7 @@ public class CacheAdmin extends Configured implements Tool {
     }
   }
 
-  private static class ModifyCachePoolCommand implements Command {
+  private static class ModifyCachePoolCommand implements AdminHelper.Command {
 
     @Override
     public String getName() {
@@ -719,7 +659,7 @@ public class CacheAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      TableListing listing = getOptionDescriptionListing();
+      TableListing listing = AdminHelper.getOptionDescriptionListing();
 
       listing.addRow("<name>", "Name of the pool to modify.");
       listing.addRow("<owner>", "Username of the owner of the pool");
@@ -733,7 +673,7 @@ public class CacheAdmin extends Configured implements Tool {
       return getShortUsage() + "\n" +
           WordUtils.wrap("Modifies the metadata of an existing cache pool. " +
           "See usage of " + AddCachePoolCommand.NAME + " for more details.",
-          MAX_LINE_WIDTH) + "\n\n" +
+          AdminHelper.MAX_LINE_WIDTH) + "\n\n" +
           listing.toString();
     }
 
@@ -745,11 +685,11 @@ public class CacheAdmin extends Configured implements Tool {
       Integer mode = (modeString == null) ?
           null : Integer.parseInt(modeString, 8);
       String limitString = StringUtils.popOptionWithArgument("-limit", args);
-      Long limit = parseLimitString(limitString);
+      Long limit = AdminHelper.parseLimitString(limitString);
       String maxTtlString = StringUtils.popOptionWithArgument("-maxTtl", args);
-      Long maxTtl = null;
+      Long maxTtl;
       try {
-        maxTtl = parseTtlString(maxTtlString);
+        maxTtl = AdminHelper.parseTtlString(maxTtlString);
       } catch (IOException e) {
         System.err.println(
             "Error while parsing maxTtl value: " + e.getMessage());
@@ -794,11 +734,11 @@ public class CacheAdmin extends Configured implements Tool {
             "change in the cache pool.");
         return 1;
       }
-      DistributedFileSystem dfs = getDFS(conf);
+      DistributedFileSystem dfs = AdminHelper.getDFS(conf);
       try {
         dfs.modifyCachePool(info);
       } catch (IOException e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
       System.out.print("Successfully modified cache pool " + name);
@@ -827,7 +767,7 @@ public class CacheAdmin extends Configured implements Tool {
     }
   }
 
-  private static class RemoveCachePoolCommand implements Command {
+  private static class RemoveCachePoolCommand implements AdminHelper.Command {
 
     @Override
     public String getName() {
@@ -843,7 +783,7 @@ public class CacheAdmin extends Configured implements Tool {
     public String getLongUsage() {
       return getShortUsage() + "\n" +
           WordUtils.wrap("Remove a cache pool. This also uncaches paths " +
-              "associated with the pool.\n\n", MAX_LINE_WIDTH) +
+              "associated with the pool.\n\n", AdminHelper.MAX_LINE_WIDTH) +
           "<name>  Name of the cache pool to remove.\n";
     }
 
@@ -861,11 +801,11 @@ public class CacheAdmin extends Configured implements Tool {
         System.err.println("Usage is " + getShortUsage());
         return 1;
       }
-      DistributedFileSystem dfs = getDFS(conf);
+      DistributedFileSystem dfs = AdminHelper.getDFS(conf);
       try {
         dfs.removeCachePool(name);
       } catch (IOException e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
       System.out.println("Successfully removed cache pool " + name + ".");
@@ -873,7 +813,7 @@ public class CacheAdmin extends Configured implements Tool {
     }
   }
 
-  private static class ListCachePoolsCommand implements Command {
+  private static class ListCachePoolsCommand implements AdminHelper.Command {
 
     @Override
     public String getName() {
@@ -887,15 +827,14 @@ public class CacheAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      TableListing listing = getOptionDescriptionListing();
+      TableListing listing = AdminHelper.getOptionDescriptionListing();
       listing.addRow("-stats", "Display additional cache pool statistics.");
       listing.addRow("<name>", "If specified, list only the named cache pool.");
 
       return getShortUsage() + "\n" +
           WordUtils.wrap("Display information about one or more cache pools, " +
-              "e.g. name, owner, group, permissions, etc.", MAX_LINE_WIDTH) +
-          "\n\n" +
-          listing.toString();
+              "e.g. name, owner, group, permissions, etc.",
+              AdminHelper.MAX_LINE_WIDTH) + "\n\n" + listing.toString();
     }
 
     @Override
@@ -908,7 +847,7 @@ public class CacheAdmin extends Configured implements Tool {
         System.err.println("Usage is " + getShortUsage());
         return 1;
       }
-      DistributedFileSystem dfs = getDFS(conf);
+      DistributedFileSystem dfs = AdminHelper.getDFS(conf);
       TableListing.Builder builder = new TableListing.Builder().
           addField("NAME", Justification.LEFT).
           addField("OWNER", Justification.LEFT).
@@ -949,7 +888,7 @@ public class CacheAdmin extends Configured implements Tool {
             String maxTtlString = null;
 
             if (maxTtl != null) {
-              if (maxTtl.longValue() == CachePoolInfo.RELATIVE_EXPIRY_NEVER) {
+              if (maxTtl == CachePoolInfo.RELATIVE_EXPIRY_NEVER) {
                 maxTtlString  = "never";
               } else {
                 maxTtlString = DFSUtil.durationToString(maxTtl);
@@ -972,7 +911,7 @@ public class CacheAdmin extends Configured implements Tool {
           }
         }
       } catch (IOException e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
       System.out.print(String.format("Found %d result%s.%n", numResults,
@@ -985,61 +924,7 @@ public class CacheAdmin extends Configured implements Tool {
     }
   }
 
-  private static class HelpCommand implements Command {
-    @Override
-    public String getName() {
-      return "-help";
-    }
-
-    @Override
-    public String getShortUsage() {
-      return "[-help <command-name>]\n";
-    }
-
-    @Override
-    public String getLongUsage() {
-      TableListing listing = getOptionDescriptionListing();
-      listing.addRow("<command-name>", "The command for which to get " +
-          "detailed help. If no command is specified, print detailed help for " +
-          "all commands");
-      return getShortUsage() + "\n" +
-        "Get detailed help about a command.\n\n" +
-        listing.toString();
-    }
-
-    @Override
-    public int run(Configuration conf, List<String> args) throws IOException {
-      if (args.size() == 0) {
-        for (Command command : COMMANDS) {
-          System.err.println(command.getLongUsage());
-        }
-        return 0;
-      }
-      if (args.size() != 1) {
-        System.out.println("You must give exactly one argument to -help.");
-        return 0;
-      }
-      String commandName = args.get(0);
-      // prepend a dash to match against the command names
-      Command command = determineCommand("-"+commandName);
-      if (command == null) {
-        System.err.print("Sorry, I don't know the command '" +
-          commandName + "'.\n");
-        System.err.print("Valid help command names are:\n");
-        String separator = "";
-        for (Command c : COMMANDS) {
-          System.err.print(separator + c.getName().substring(1));
-          separator = ", ";
-        }
-        System.err.print("\n");
-        return 1;
-      }
-      System.err.print(command.getLongUsage());
-      return 0;
-    }
-  }
-
-  private static final Command[] COMMANDS = {
+  private static final AdminHelper.Command[] COMMANDS = {
     new AddCacheDirectiveInfoCommand(),
     new ModifyCacheDirectiveInfoCommand(),
     new ListCacheDirectiveInfoCommand(),
@@ -1048,29 +933,6 @@ public class CacheAdmin extends Configured implements Tool {
     new AddCachePoolCommand(),
     new ModifyCachePoolCommand(),
     new RemoveCachePoolCommand(),
-    new ListCachePoolsCommand(),
-    new HelpCommand(),
+    new ListCachePoolsCommand()
   };
-
-  private static void printUsage(boolean longUsage) {
-    System.err.println(
-        "Usage: bin/hdfs cacheadmin [COMMAND]");
-    for (Command command : COMMANDS) {
-      if (longUsage) {
-        System.err.print(command.getLongUsage());
-      } else {
-        System.err.print("          " + command.getShortUsage());
-      }
-    }
-    System.err.println();
-  }
-
-  private static Command determineCommand(String commandName) {
-    for (int i = 0; i < COMMANDS.length; i++) {
-      if (COMMANDS[i].getName().equals(commandName)) {
-        return COMMANDS[i];
-      }
-    }
-    return null;
-  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/CryptoAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/CryptoAdmin.java
@@ -24,10 +24,10 @@ import java.util.List;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.client.HdfsAdmin;
 import org.apache.hadoop.hdfs.protocol.EncryptionZone;
 import org.apache.hadoop.tools.TableListing;
 import org.apache.hadoop.util.StringUtils;
@@ -38,11 +38,6 @@ import org.apache.hadoop.util.Tool;
  */
 @InterfaceAudience.Private
 public class CryptoAdmin extends Configured implements Tool {
-
-  /**
-   * Maximum length for printed lines
-   */
-  private static final int MAX_LINE_WIDTH = 80;
 
   public CryptoAdmin() {
     this(null);
@@ -55,16 +50,17 @@ public class CryptoAdmin extends Configured implements Tool {
   @Override
   public int run(String[] args) throws IOException {
     if (args.length == 0) {
-      printUsage(false);
+      AdminHelper.printUsage(false, "crypto", COMMANDS);
       return 1;
     }
-    final Command command = determineCommand(args[0]);
+    final AdminHelper.Command command = AdminHelper.determineCommand(args[0],
+        COMMANDS);
     if (command == null) {
       System.err.println("Can't understand command '" + args[0] + "'");
       if (!args[0].startsWith("-")) {
         System.err.println("Command names must start with dashes.");
       }
-      printUsage(false);
+      AdminHelper.printUsage(false, "crypto", COMMANDS);
       return 1;
     }
     final List<String> argsList = new LinkedList<String>();
@@ -84,16 +80,6 @@ public class CryptoAdmin extends Configured implements Tool {
     System.exit(cryptoAdmin.run(argsArray));
   }
 
-  private static DistributedFileSystem getDFS(Configuration conf)
-      throws IOException {
-    final FileSystem fs = FileSystem.get(conf);
-    if (!(fs instanceof DistributedFileSystem)) {
-      throw new IllegalArgumentException("FileSystem " + fs.getUri() +
-      " is not an HDFS file system");
-    }
-    return (DistributedFileSystem) fs;
-  }
-
   /**
    * NN exceptions contain the stack trace as part of the exception message.
    * When it's a known error, pretty-print the error and squish the stack trace.
@@ -103,21 +89,7 @@ public class CryptoAdmin extends Configured implements Tool {
       e.getLocalizedMessage().split("\n")[0];
   }
 
-  private static TableListing getOptionDescriptionListing() {
-    final TableListing listing = new TableListing.Builder()
-      .addField("").addField("", true)
-      .wrapWidth(MAX_LINE_WIDTH).hideHeaders().build();
-    return listing;
-  }
-
-  interface Command {
-    String getName();
-    String getShortUsage();
-    String getLongUsage();
-    int run(Configuration conf, List<String> args) throws IOException;
-  }
-
-  private static class CreateZoneCommand implements Command {
+  private static class CreateZoneCommand implements AdminHelper.Command {
     @Override
     public String getName() {
       return "-createZone";
@@ -130,7 +102,7 @@ public class CryptoAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      final TableListing listing = getOptionDescriptionListing();
+      final TableListing listing = AdminHelper.getOptionDescriptionListing();
       listing.addRow("<path>", "The path of the encryption zone to create. " +
         "It must be an empty directory.");
       listing.addRow("<keyName>", "Name of the key to use for the " +
@@ -160,9 +132,10 @@ public class CryptoAdmin extends Configured implements Tool {
         return 1;
       }
 
-      final DistributedFileSystem dfs = getDFS(conf);
+      Path p = new Path(path);
+      HdfsAdmin admin = new HdfsAdmin(p.toUri(), conf);
       try {
-        dfs.createEncryptionZone(new Path(path), keyName);
+        admin.createEncryptionZone(p, keyName);
         System.out.println("Added encryption zone " + path);
       } catch (IOException e) {
         System.err.println(prettifyException(e));
@@ -173,7 +146,7 @@ public class CryptoAdmin extends Configured implements Tool {
     }
   }
 
-  private static class ListZonesCommand implements Command {
+  private static class ListZonesCommand implements AdminHelper.Command {
     @Override
     public String getName() {
       return "-listZones";
@@ -197,11 +170,11 @@ public class CryptoAdmin extends Configured implements Tool {
         return 1;
       }
 
-      final DistributedFileSystem dfs = getDFS(conf);
+      final DistributedFileSystem dfs = AdminHelper.getDFS(conf);
       try {
         final TableListing listing = new TableListing.Builder()
           .addField("").addField("", true)
-          .wrapWidth(MAX_LINE_WIDTH).hideHeaders().build();
+          .wrapWidth(AdminHelper.MAX_LINE_WIDTH).hideHeaders().build();
         final RemoteIterator<EncryptionZone> it = dfs.listEncryptionZones();
         while (it.hasNext()) {
           EncryptionZone ez = it.next();
@@ -217,85 +190,8 @@ public class CryptoAdmin extends Configured implements Tool {
     }
   }
 
-  private static class HelpCommand implements Command {
-    @Override
-    public String getName() {
-      return "-help";
-    }
-
-    @Override
-    public String getShortUsage() {
-      return "[-help <command-name>]\n";
-    }
-
-    @Override
-    public String getLongUsage() {
-      final TableListing listing = getOptionDescriptionListing();
-      listing.addRow("<command-name>", "The command for which to get " +
-          "detailed help. If no command is specified, print detailed help for " +
-          "all commands");
-      return getShortUsage() + "\n" +
-        "Get detailed help about a command.\n\n" +
-        listing.toString();
-    }
-
-    @Override
-    public int run(Configuration conf, List<String> args) throws IOException {
-      if (args.size() == 0) {
-        for (Command command : COMMANDS) {
-          System.err.println(command.getLongUsage());
-        }
-        return 0;
-      }
-      if (args.size() != 1) {
-        System.out.println("You must give exactly one argument to -help.");
-        return 0;
-      }
-      final String commandName = args.get(0);
-      // prepend a dash to match against the command names
-      final Command command = determineCommand("-"+commandName);
-      if (command == null) {
-        System.err.print("Sorry, I don't know the command '" +
-          commandName + "'.\n");
-        System.err.print("Valid help command names are:\n");
-        String separator = "";
-        for (Command c : COMMANDS) {
-          System.err.print(separator + c.getName().substring(1));
-          separator = ", ";
-        }
-        System.err.print("\n");
-        return 1;
-      }
-      System.err.print(command.getLongUsage());
-      return 0;
-    }
-  }
-
-  private static final Command[] COMMANDS = {
+  private static final AdminHelper.Command[] COMMANDS = {
     new CreateZoneCommand(),
-    new ListZonesCommand(),
-    new HelpCommand(),
+    new ListZonesCommand()
   };
-
-  private static void printUsage(boolean longUsage) {
-    System.err.println(
-        "Usage: bin/hdfs crypto [COMMAND]");
-    for (Command command : COMMANDS) {
-      if (longUsage) {
-        System.err.print(command.getLongUsage());
-      } else {
-        System.err.print("          " + command.getShortUsage());
-      }
-    }
-    System.err.println();
-  }
-
-  private static Command determineCommand(String commandName) {
-    for (int i = 0; i < COMMANDS.length; i++) {
-      if (COMMANDS[i].getName().equals(commandName)) {
-        return COMMANDS[i];
-      }
-    }
-    return null;
-  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -114,6 +114,9 @@ public class DFSAdmin extends FsShell {
 
     @Override
     public void run(PathData pathData) throws IOException {
+      if (!(pathData.fs instanceof DistributedFileSystem)) {
+        pathData = PathData.resolveFsPath(pathData, getConf());
+      }
       FileSystem fs = pathData.fs;
       if (!(fs instanceof DistributedFileSystem)) {
         throw new IllegalArgumentException("FileSystem " + fs.getUri()

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/StoragePolicyAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/StoragePolicyAdmin.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdfs.tools;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.protocol.BlockStoragePolicy;
@@ -28,6 +27,7 @@ import org.apache.hadoop.hdfs.server.blockmanagement.BlockStoragePolicySuite;
 import org.apache.hadoop.tools.TableListing;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -38,37 +38,12 @@ import java.util.List;
  * This class implements block storage policy operations.
  */
 public class StoragePolicyAdmin extends Configured implements Tool {
-  private static final int MAX_LINE_WIDTH = 80;
 
   public static void main(String[] argsArray) throws Exception {
     final StoragePolicyAdmin admin = new StoragePolicyAdmin(new
         Configuration());
-    System.exit(admin.run(argsArray));
-  }
-
-  private static DistributedFileSystem getDFS(Configuration conf)
-      throws IOException {
-    final FileSystem fs = FileSystem.get(conf);
-    if (!(fs instanceof DistributedFileSystem)) {
-      throw new IllegalArgumentException("FileSystem " + fs.getUri() +
-          " is not an HDFS file system");
-    }
-    return (DistributedFileSystem) fs;
-  }
-
-  /**
-   * NN exceptions contain the stack trace as part of the exception message.
-   * When it's a known error, pretty-print the error and squish the stack trace.
-   */
-  private static String prettifyException(Exception e) {
-    return e.getClass().getSimpleName() + ": " +
-        e.getLocalizedMessage().split("\n")[0];
-  }
-
-  private static TableListing getOptionDescriptionListing() {
-    return new TableListing.Builder()
-        .addField("").addField("", true)
-        .wrapWidth(MAX_LINE_WIDTH).hideHeaders().build();
+    int res = ToolRunner.run(admin, argsArray);
+    System.exit(res);
   }
 
   public StoragePolicyAdmin(Configuration conf) {
@@ -78,37 +53,34 @@ public class StoragePolicyAdmin extends Configured implements Tool {
   @Override
   public int run(String[] args) throws Exception {
     if (args.length == 0) {
-      printUsage(false);
+      AdminHelper.printUsage(false, "storagepolicies", COMMANDS);
+      ToolRunner.printGenericCommandUsage(System.err);
       return 1;
     }
-    final Command command = determineCommand(args[0]);
+    final AdminHelper.Command command = AdminHelper.determineCommand(args[0],
+        COMMANDS);
     if (command == null) {
       System.err.println("Can't understand command '" + args[0] + "'");
       if (!args[0].startsWith("-")) {
         System.err.println("Command names must start with dashes.");
       }
-      printUsage(false);
+      AdminHelper.printUsage(false, "storagepolicies", COMMANDS);
+      ToolRunner.printGenericCommandUsage(System.err);
       return 1;
     }
-    final List<String> argsList = new LinkedList<String>();
+    final List<String> argsList = new LinkedList<>();
     argsList.addAll(Arrays.asList(args).subList(1, args.length));
     try {
       return command.run(getConf(), argsList);
     } catch (IllegalArgumentException e) {
-      System.err.println(prettifyException(e));
+      System.err.println(AdminHelper.prettifyException(e));
       return -1;
     }
   }
 
-  interface Command {
-    String getName();
-    String getShortUsage();
-    String getLongUsage();
-    int run(Configuration conf, List<String> args) throws IOException;
-  }
-
   /** Command to list all the existing storage policies */
-  private static class ListStoragePoliciesCommand implements Command {
+  private static class ListStoragePoliciesCommand
+      implements AdminHelper.Command {
     @Override
     public String getName() {
       return "-listPolicies";
@@ -127,7 +99,7 @@ public class StoragePolicyAdmin extends Configured implements Tool {
 
     @Override
     public int run(Configuration conf, List<String> args) throws IOException {
-      final DistributedFileSystem dfs = getDFS(conf);
+      final DistributedFileSystem dfs = AdminHelper.getDFS(conf);
       try {
         BlockStoragePolicy[] policies = dfs.getStoragePolicies();
         System.out.println("Block Storage Policies:");
@@ -137,7 +109,7 @@ public class StoragePolicyAdmin extends Configured implements Tool {
           }
         }
       } catch (IOException e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
       return 0;
@@ -145,7 +117,7 @@ public class StoragePolicyAdmin extends Configured implements Tool {
   }
 
   /** Command to get the storage policy of a file/directory */
-  private static class GetStoragePolicyCommand implements Command {
+  private static class GetStoragePolicyCommand implements AdminHelper.Command {
     @Override
     public String getName() {
       return "-getStoragePolicy";
@@ -158,7 +130,7 @@ public class StoragePolicyAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      final TableListing listing = getOptionDescriptionListing();
+      final TableListing listing = AdminHelper.getOptionDescriptionListing();
       listing.addRow("<path>",
           "The path of the file/directory for getting the storage policy");
       return getShortUsage() + "\n" +
@@ -175,9 +147,11 @@ public class StoragePolicyAdmin extends Configured implements Tool {
         return 1;
       }
 
-      final DistributedFileSystem dfs = getDFS(conf);
+      Path p = new Path(path);
+      final DistributedFileSystem dfs = AdminHelper.getDFS(p.toUri(), conf);
       try {
-        HdfsFileStatus status = dfs.getClient().getFileInfo(path);
+        HdfsFileStatus status = dfs.getClient().getFileInfo(
+            Path.getPathWithoutSchemeAndAuthority(p).toString());
         if (status == null) {
           System.err.println("File/Directory does not exist: " + path);
           return 2;
@@ -188,14 +162,14 @@ public class StoragePolicyAdmin extends Configured implements Tool {
           return 0;
         }
         BlockStoragePolicy[] policies = dfs.getStoragePolicies();
-        for (BlockStoragePolicy p : policies) {
-          if (p.getId() == storagePolicyId) {
-            System.out.println("The storage policy of " + path + ":\n" + p);
+        for (BlockStoragePolicy policy : policies) {
+          if (policy.getId() == storagePolicyId) {
+            System.out.println("The storage policy of " + path + ":\n" + policy);
             return 0;
           }
         }
       } catch (Exception e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
       System.err.println("Cannot identify the storage policy for " + path);
@@ -204,7 +178,7 @@ public class StoragePolicyAdmin extends Configured implements Tool {
   }
 
   /** Command to set the storage policy to a file/directory */
-  private static class SetStoragePolicyCommand implements Command {
+  private static class SetStoragePolicyCommand implements AdminHelper.Command {
     @Override
     public String getName() {
       return "-setStoragePolicy";
@@ -217,7 +191,7 @@ public class StoragePolicyAdmin extends Configured implements Tool {
 
     @Override
     public String getLongUsage() {
-      TableListing listing = getOptionDescriptionListing();
+      TableListing listing = AdminHelper.getOptionDescriptionListing();
       listing.addRow("<path>", "The path of the file/directory to set storage" +
           " policy");
       listing.addRow("<policy>", "The name of the block storage policy");
@@ -242,98 +216,22 @@ public class StoragePolicyAdmin extends Configured implements Tool {
             getLongUsage());
         return 1;
       }
-
-      final DistributedFileSystem dfs = getDFS(conf);
+      Path p = new Path(path);
+      final DistributedFileSystem dfs = AdminHelper.getDFS(p.toUri(), conf);
       try {
-        dfs.setStoragePolicy(new Path(path), policyName);
+        dfs.setStoragePolicy(p, policyName);
         System.out.println("Set storage policy " + policyName + " on " + path);
       } catch (Exception e) {
-        System.err.println(prettifyException(e));
+        System.err.println(AdminHelper.prettifyException(e));
         return 2;
       }
       return 0;
     }
   }
 
-  private static class HelpCommand implements Command {
-    @Override
-    public String getName() {
-      return "-help";
-    }
-
-    @Override
-    public String getShortUsage() {
-      return "[-help <command-name>]\n";
-    }
-
-    @Override
-    public String getLongUsage() {
-      final TableListing listing = getOptionDescriptionListing();
-      listing.addRow("<command-name>", "The command for which to get " +
-          "detailed help. If no command is specified, print detailed help for " +
-          "all commands");
-      return getShortUsage() + "\n" +
-          "Get detailed help about a command.\n\n" +
-          listing.toString();
-    }
-
-    @Override
-    public int run(Configuration conf, List<String> args) throws IOException {
-      if (args.size() == 0) {
-        for (Command command : COMMANDS) {
-          System.err.println(command.getLongUsage());
-        }
-        return 0;
-      }
-      if (args.size() != 1) {
-        System.out.println("You must give exactly one argument to -help.");
-        return 0;
-      }
-      final String commandName = args.get(0);
-      // prepend a dash to match against the command names
-      final Command command = determineCommand("-" + commandName);
-      if (command == null) {
-        System.err.print("Unknown command '" + commandName + "'.\n");
-        System.err.print("Valid help command names are:\n");
-        String separator = "";
-        for (Command c : COMMANDS) {
-          System.err.print(separator + c.getName().substring(1));
-          separator = ", ";
-        }
-        System.err.print("\n");
-        return 1;
-      }
-      System.err.print(command.getLongUsage());
-      return 0;
-    }
-  }
-
-  private static final Command[] COMMANDS = {
+  private static final AdminHelper.Command[] COMMANDS = {
       new ListStoragePoliciesCommand(),
       new SetStoragePolicyCommand(),
-      new GetStoragePolicyCommand(),
-      new HelpCommand()
+      new GetStoragePolicyCommand()
   };
-
-  private static void printUsage(boolean longUsage) {
-    System.err.println(
-        "Usage: bin/hdfs storagepolicies [COMMAND]");
-    for (Command command : COMMANDS) {
-      if (longUsage) {
-        System.err.print(command.getLongUsage());
-      } else {
-        System.err.print("          " + command.getShortUsage());
-      }
-    }
-    System.err.println();
-  }
-
-  private static Command determineCommand(String commandName) {
-    for (Command COMMAND : COMMANDS) {
-      if (COMMAND.getName().equals(commandName)) {
-        return COMMAND;
-      }
-    }
-    return null;
-  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/snapshot/SnapshotDiff.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/snapshot/SnapshotDiff.java
@@ -20,10 +20,12 @@ package org.apache.hadoop.hdfs.tools.snapshot;
 import java.io.IOException;
 
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.util.Tool;
@@ -41,6 +43,19 @@ import org.apache.hadoop.util.ToolRunner;
  */
 @InterfaceAudience.Private
 public class SnapshotDiff extends Configured implements Tool {
+  /**
+   * Construct a SnapshotDiff object.
+   */
+  public SnapshotDiff() {
+    this(new HdfsConfiguration());
+  }
+
+  /**
+   * Construct a SnapshotDiff object.
+   */
+  public SnapshotDiff(Configuration conf) {
+    super(conf);
+  }
   private static String getSnapshotName(String name) {
     if (Path.CUR_DIR.equals(name)) { // current directory
       return "";
@@ -72,8 +87,8 @@ public class SnapshotDiff extends Configured implements Tool {
       System.err.println("Usage: \n" + description);
       return 1;
     }
-    
-    FileSystem fs = FileSystem.get(getConf());
+
+    FileSystem fs = FileSystem.get(new Path(argv[0]).toUri(), getConf());
     if (! (fs instanceof DistributedFileSystem)) {
       System.err.println(
           "SnapshotDiff can only be used in DistributedFileSystem");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestQuota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestQuota.java
@@ -17,15 +17,22 @@
  */
 package org.apache.hadoop.hdfs;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.security.PrivilegedExceptionAction;
+import java.util.List;
+import java.util.Scanner;
 
+import com.google.common.io.Files;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -35,31 +42,112 @@ import org.apache.hadoop.hdfs.protocol.DSQuotaExceededException;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocol.NSQuotaExceededException;
 import org.apache.hadoop.hdfs.protocol.QuotaExceededException;
+import org.apache.hadoop.hdfs.server.namenode.FSImageTestUtil;
 import org.apache.hadoop.hdfs.tools.DFSAdmin;
 import org.apache.hadoop.hdfs.web.WebHdfsFileSystem;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.PathUtils;
+import org.apache.hadoop.util.ToolRunner;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
 
 /** A class for testing quota-related commands */
 public class TestQuota {
-  
-  private void runCommand(DFSAdmin admin, boolean expectError, String... args) 
+
+  private static Configuration conf = null;
+  private static final ByteArrayOutputStream OUT_STREAM = new ByteArrayOutputStream();
+  private static final ByteArrayOutputStream ERR_STREAM = new ByteArrayOutputStream();
+  private static final PrintStream OLD_OUT = System.out;
+  private static final PrintStream OLD_ERR = System.err;
+  private static MiniDFSCluster cluster;
+  private static DistributedFileSystem dfs;
+  private static FileSystem webhdfs;
+  /* set a smaller block size so that we can test with smaller space quotas */
+  private static final int DEFAULT_BLOCK_SIZE = 512;
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    conf = new HdfsConfiguration();
+    File testDir = Files.createTempDir();
+    conf.set(
+        MiniDFSCluster.HDFS_MINIDFS_BASEDIR,
+        testDir.getAbsolutePath());
+    conf.setInt("dfs.content-summary.limit", 4);
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, DEFAULT_BLOCK_SIZE);
+    /*
+     * Make it relinquish locks. When run serially, the result should be
+     * identical.
+     */
+    conf.setInt(DFSConfigKeys.DFS_CONTENT_SUMMARY_LIMIT_KEY, 2);
+    restartCluster();
+
+    dfs = (DistributedFileSystem) cluster.getFileSystem();
+    redirectStream();
+
+    final String nnAddr = conf.get(DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY);
+    final String webhdfsuri = "webhdfs://" + nnAddr;
+    System.out.println("webhdfsuri=" + webhdfsuri);
+    webhdfs = new Path(webhdfsuri).getFileSystem(conf);
+  }
+
+  private static void restartCluster() throws IOException {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+    cluster.waitActive();
+  }
+
+  private static void redirectStream() {
+    System.setOut(new PrintStream(OUT_STREAM));
+    System.setErr(new PrintStream(ERR_STREAM));
+  }
+
+  private static void resetStream() {
+    OUT_STREAM.reset();
+    ERR_STREAM.reset();
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    try {
+      System.out.flush();
+      System.err.flush();
+    } finally {
+      System.setOut(OLD_OUT);
+      System.setErr(OLD_ERR);
+    }
+
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+
+    resetStream();
+  }
+
+  private void runCommand(DFSAdmin admin, boolean expectError, String... args)
                          throws Exception {
     runCommand(admin, args, expectError);
   }
-  
+
   private void runCommand(DFSAdmin admin, String args[], boolean expectEror)
   throws Exception {
     int val = admin.run(args);
     if (expectEror) {
-      assertEquals(val, -1);
+      assertEquals(-1, val);
     } else {
       assertTrue(val>=0);
     }
   }
-  
+
   /**
    * Tests to make sure we're getting human readable Quota exception messages
    * Test for @link{ NSQuotaExceededException, DSQuotaExceededException}
@@ -71,19 +159,19 @@ public class TestQuota {
     try {
       throw new DSQuotaExceededException(bytes, bytes);
     } catch(DSQuotaExceededException e) {
-      
+
       assertEquals("The DiskSpace quota is exceeded: quota = 1024 B = 1 KB"
           + " but diskspace consumed = 1024 B = 1 KB", e.getMessage());
     }
   }
-  
-  /** Test quota related commands: 
-   *    setQuota, clrQuota, setSpaceQuota, clrSpaceQuota, and count 
+
+  /** Test quota related commands:
+   *    setQuota, clrQuota, setSpaceQuota, clrSpaceQuota, and count
    */
   @Test
   public void testQuotaCommands() throws Exception {
     final Configuration conf = new HdfsConfiguration();
-    // set a smaller block size so that we can test with smaller 
+    // set a smaller block size so that we can test with smaller
     // Space quotas
     final int DEFAULT_BLOCK_SIZE = 512;
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, DEFAULT_BLOCK_SIZE);
@@ -96,7 +184,7 @@ public class TestQuota {
                 fs instanceof DistributedFileSystem);
     final DistributedFileSystem dfs = (DistributedFileSystem)fs;
     DFSAdmin admin = new DFSAdmin(conf);
-    
+
     try {
       final int fileLen = 1024;
       final short replication = 5;
@@ -111,11 +199,11 @@ public class TestQuota {
       //try setting space quota with a 'binary prefix'
       runCommand(admin, false, "-setSpaceQuota", "2t", parent.toString());
       assertEquals(2L<<40, dfs.getContentSummary(parent).getSpaceQuota());
-      
-      // set diskspace quota to 10000 
-      runCommand(admin, false, "-setSpaceQuota", 
+
+      // set diskspace quota to 10000
+      runCommand(admin, false, "-setSpaceQuota",
                  Long.toString(spaceQuota), parent.toString());
-      
+
       // 2: create directory /test/data0
       final Path childDir0 = new Path(parent, "data0");
       assertTrue(dfs.mkdirs(childDir0));
@@ -123,14 +211,14 @@ public class TestQuota {
       // 3: create a file /test/datafile0
       final Path childFile0 = new Path(parent, "datafile0");
       DFSTestUtil.createFile(fs, childFile0, fileLen, replication, 0);
-      
+
       // 4: count -q /test
       ContentSummary c = dfs.getContentSummary(parent);
       assertEquals(c.getFileCount()+c.getDirectoryCount(), 3);
       assertEquals(c.getQuota(), 3);
       assertEquals(c.getSpaceConsumed(), fileLen*replication);
       assertEquals(c.getSpaceQuota(), spaceQuota);
-      
+
       // 5: count -q /test/data0
       c = dfs.getContentSummary(childDir0);
       assertEquals(c.getFileCount()+c.getDirectoryCount(), 1);
@@ -148,9 +236,9 @@ public class TestQuota {
         hasException = true;
       }
       assertTrue(hasException);
-      
+
       OutputStream fout;
-      
+
       // 7: create a file /test/datafile1
       final Path childFile1 = new Path(parent, "datafile1");
       hasException = false;
@@ -160,21 +248,21 @@ public class TestQuota {
         hasException = true;
       }
       assertTrue(hasException);
-      
+
       // 8: clear quota /test
       runCommand(admin, new String[]{"-clrQuota", parent.toString()}, false);
       c = dfs.getContentSummary(parent);
       assertEquals(c.getQuota(), -1);
       assertEquals(c.getSpaceQuota(), spaceQuota);
-      
+
       // 9: clear quota /test/data0
       runCommand(admin, new String[]{"-clrQuota", childDir0.toString()}, false);
       c = dfs.getContentSummary(childDir0);
       assertEquals(c.getQuota(), -1);
-      
+
       // 10: create a file /test/datafile1
       fout = dfs.create(childFile1, replication);
-      
+
       // 10.s: but writing fileLen bytes should result in an quota exception
       try {
         fout.write(new byte[fileLen]);
@@ -183,30 +271,30 @@ public class TestQuota {
       } catch (QuotaExceededException e) {
         IOUtils.closeStream(fout);
       }
-      
+
       //delete the file
       dfs.delete(childFile1, false);
-      
+
       // 9.s: clear diskspace quota
       runCommand(admin, false, "-clrSpaceQuota", parent.toString());
       c = dfs.getContentSummary(parent);
       assertEquals(c.getQuota(), -1);
-      assertEquals(c.getSpaceQuota(), -1);       
-      
+      assertEquals(c.getSpaceQuota(), -1);
+
       // now creating childFile1 should succeed
       DFSTestUtil.createFile(dfs, childFile1, fileLen, replication, 0);
-      
+
       // 11: set the quota of /test to be 1
-      // HADOOP-5872 - we can set quota even if it is immediately violated 
+      // HADOOP-5872 - we can set quota even if it is immediately violated
       args = new String[]{"-setQuota", "1", parent.toString()};
       runCommand(admin, args, false);
       runCommand(admin, false, "-setSpaceQuota",  // for space quota
                  Integer.toString(fileLen), args[2]);
-      
+
       // 12: set the quota of /test/data0 to be 1
       args = new String[]{"-setQuota", "1", childDir0.toString()};
       runCommand(admin, args, false);
-      
+
       // 13: not able create a directory under data0
       hasException = false;
       try {
@@ -218,7 +306,7 @@ public class TestQuota {
       c = dfs.getContentSummary(childDir0);
       assertEquals(c.getDirectoryCount()+c.getFileCount(), 1);
       assertEquals(c.getQuota(), 1);
-      
+
       // 14a: set quota on a non-existent directory
       Path nonExistentPath = new Path("/test1");
       assertFalse(dfs.exists(nonExistentPath));
@@ -226,71 +314,71 @@ public class TestQuota {
       runCommand(admin, args, true);
       runCommand(admin, true, "-setSpaceQuota", "1g", // for space quota
                  nonExistentPath.toString());
-      
+
       // 14b: set quota on a file
       assertTrue(dfs.isFile(childFile0));
       args[1] = childFile0.toString();
       runCommand(admin, args, true);
       // same for space quota
       runCommand(admin, true, "-setSpaceQuota", "1t", args[1]);
-      
+
       // 15a: clear quota on a file
       args[0] = "-clrQuota";
       runCommand(admin, args, true);
       runCommand(admin, true, "-clrSpaceQuota", args[1]);
-      
+
       // 15b: clear quota on a non-existent directory
       args[1] = nonExistentPath.toString();
       runCommand(admin, args, true);
       runCommand(admin, true, "-clrSpaceQuota", args[1]);
-      
+
       // 16a: set the quota of /test to be 0
       args = new String[]{"-setQuota", "0", parent.toString()};
       runCommand(admin, args, true);
       runCommand(admin, true, "-setSpaceQuota", "0", args[2]);
-      
+
       // 16b: set the quota of /test to be -1
       args[1] = "-1";
       runCommand(admin, args, true);
       runCommand(admin, true, "-setSpaceQuota", args[1], args[2]);
-      
+
       // 16c: set the quota of /test to be Long.MAX_VALUE+1
       args[1] = String.valueOf(Long.MAX_VALUE+1L);
       runCommand(admin, args, true);
       runCommand(admin, true, "-setSpaceQuota", args[1], args[2]);
-      
+
       // 16d: set the quota of /test to be a non integer
       args[1] = "33aa1.5";
       runCommand(admin, args, true);
       runCommand(admin, true, "-setSpaceQuota", args[1], args[2]);
-      
+
       // 16e: set space quota with a value larger than Long.MAX_VALUE
-      runCommand(admin, true, "-setSpaceQuota", 
+      runCommand(admin, true, "-setSpaceQuota",
                  (Long.MAX_VALUE/1024/1024 + 1024) + "m", args[2]);
-      
+
       // 17:  setQuota by a non-administrator
       final String username = "userxx";
-      UserGroupInformation ugi = 
-        UserGroupInformation.createUserForTesting(username, 
+      UserGroupInformation ugi =
+        UserGroupInformation.createUserForTesting(username,
                                                   new String[]{"groupyy"});
-      
+
       final String[] args2 = args.clone(); // need final ref for doAs block
       ugi.doAs(new PrivilegedExceptionAction<Object>() {
         @Override
         public Object run() throws Exception {
-          assertEquals("Not running as new user", username, 
+          assertEquals("Not running as new user", username,
               UserGroupInformation.getCurrentUser().getShortUserName());
           DFSAdmin userAdmin = new DFSAdmin(conf);
-          
+
           args2[1] = "100";
           runCommand(userAdmin, args2, true);
           runCommand(userAdmin, true, "-setSpaceQuota", "1g", args2[2]);
-          
+
           // 18: clrQuota by a non-administrator
           String[] args3 = new String[] {"-clrQuota", parent.toString()};
           runCommand(userAdmin, args3, true);
-          runCommand(userAdmin, true, "-clrSpaceQuota",  args3[1]); 
-          
+          runCommand(userAdmin, true, "-clrSpaceQuota",  args3[1]);
+
           return null;
         }
       });
@@ -316,7 +404,7 @@ public class TestQuota {
       final Path childFile3 = new Path(childDir2, "datafile3");
       final long spaceQuota2 = DEFAULT_BLOCK_SIZE * replication;
       final long fileLen2 = DEFAULT_BLOCK_SIZE;
-      // set space quota to a real low value 
+      // set space quota to a real low value
       runCommand(admin, false, "-setSpaceQuota", Long.toString(spaceQuota2), childDir2.toString());
       // clear space quota
       runCommand(admin, false, "-clrSpaceQuota", childDir2.toString());
@@ -340,7 +428,7 @@ public class TestQuota {
 
       runCommand(admin, true, "-clrQuota", "/");
       runCommand(admin, false, "-clrSpaceQuota", "/");
-      // set space quota to a real low value 
+      // set space quota to a real low value
       runCommand(admin, false, "-setSpaceQuota", Long.toString(spaceQuota2), "/");
       runCommand(admin, false, "-clrSpaceQuota", "/");
       DFSTestUtil.createFile(fs, childFile4, fileLen2, replication, 0);
@@ -359,7 +447,7 @@ public class TestQuota {
       cluster.shutdown();
     }
   }
-  
+
   /** Test commands that change the size of the name space:
    *  mkdirs, rename, and delete */
   @Test
@@ -370,7 +458,7 @@ public class TestQuota {
     conf.setInt(DFSConfigKeys.DFS_CONTENT_SUMMARY_LIMIT_KEY, 2);
     final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(2).build();
     final DistributedFileSystem dfs = cluster.getFileSystem();
-    
+
     try {
       // 1: create directory /nqdir0/qdir1/qdir20/nqdir30
       assertTrue(dfs.mkdirs(new Path("/nqdir0/qdir1/qdir20/nqdir30")));
@@ -457,7 +545,7 @@ public class TestQuota {
       assertTrue(hasException);
       assertTrue(dfs.exists(tempPath));
       assertFalse(dfs.exists(new Path(quotaDir3, "nqdir30")));
-      
+
       // 10.a: Rename /nqdir0/qdir1/qdir20/nqdir30 to /nqdir0/qdir1/qdir21/nqdir32
       hasException = false;
       try {
@@ -525,17 +613,17 @@ public class TestQuota {
       cluster.shutdown();
     }
   }
-  
+
   /**
    * Test HDFS operations that change disk space consumed by a directory tree.
    * namely create, rename, delete, append, and setReplication.
-   * 
+   *
    * This is based on testNamespaceCommands() above.
    */
   @Test
   public void testSpaceCommands() throws Exception {
     final Configuration conf = new HdfsConfiguration();
-    // set a smaller block size so that we can test with smaller 
+    // set a smaller block size so that we can test with smaller
     // diskspace quotas
     conf.set(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, "512");
     // Make it relinquish locks. When run serially, the result should
@@ -551,17 +639,17 @@ public class TestQuota {
       int fileLen = 1024;
       short replication = 3;
       int fileSpace = fileLen * replication;
-      
+
       // create directory /nqdir0/qdir1/qdir20/nqdir30
       assertTrue(dfs.mkdirs(new Path("/nqdir0/qdir1/qdir20/nqdir30")));
 
-      // set the quota of /nqdir0/qdir1 to 4 * fileSpace 
+      // set the quota of /nqdir0/qdir1 to 4 * fileSpace
       final Path quotaDir1 = new Path("/nqdir0/qdir1");
       dfs.setQuota(quotaDir1, HdfsConstants.QUOTA_DONT_SET, 4 * fileSpace);
       ContentSummary c = dfs.getContentSummary(quotaDir1);
       assertEquals(c.getSpaceQuota(), 4 * fileSpace);
-      
-      // set the quota of /nqdir0/qdir1/qdir20 to 6 * fileSpace 
+
+      // set the quota of /nqdir0/qdir1/qdir20 to 6 * fileSpace
       final Path quotaDir20 = new Path("/nqdir0/qdir1/qdir20");
       dfs.setQuota(quotaDir20, HdfsConstants.QUOTA_DONT_SET, 6 * fileSpace);
       c = dfs.getContentSummary(quotaDir20);
@@ -578,17 +666,17 @@ public class TestQuota {
       // 5: Create directory /nqdir0/qdir1/qdir21/nqdir32
       Path tempPath = new Path(quotaDir21, "nqdir32");
       assertTrue(dfs.mkdirs(tempPath));
-      
+
       // create a file under nqdir32/fileDir
-      DFSTestUtil.createFile(dfs, new Path(tempPath, "fileDir/file1"), fileLen, 
+      DFSTestUtil.createFile(dfs, new Path(tempPath, "fileDir/file1"), fileLen,
                              replication, 0);
       c = dfs.getContentSummary(quotaDir21);
       assertEquals(c.getSpaceConsumed(), fileSpace);
-      
+
       // Create a larger file /nqdir0/qdir1/qdir21/nqdir33/
       boolean hasException = false;
       try {
-        DFSTestUtil.createFile(dfs, new Path(quotaDir21, "nqdir33/file2"), 
+        DFSTestUtil.createFile(dfs, new Path(quotaDir21, "nqdir33/file2"),
                                2*fileLen, replication, 0);
       } catch (DSQuotaExceededException e) {
         hasException = true;
@@ -603,12 +691,12 @@ public class TestQuota {
       // Verify space before the move:
       c = dfs.getContentSummary(quotaDir20);
       assertEquals(c.getSpaceConsumed(), 0);
-      
+
       // Move /nqdir0/qdir1/qdir21/nqdir32 /nqdir0/qdir1/qdir20/nqdir30
       Path dstPath = new Path(quotaDir20, "nqdir30");
       Path srcPath = new Path(quotaDir21, "nqdir32");
       assertTrue(dfs.rename(srcPath, dstPath));
-      
+
       // verify space after the move
       c = dfs.getContentSummary(quotaDir20);
       assertEquals(c.getSpaceConsumed(), fileSpace);
@@ -618,17 +706,17 @@ public class TestQuota {
       // verify space for source for the move
       c = dfs.getContentSummary(quotaDir21);
       assertEquals(c.getSpaceConsumed(), 0);
-      
+
       final Path file2 = new Path(dstPath, "fileDir/file2");
       int file2Len = 2 * fileLen;
       // create a larger file under /nqdir0/qdir1/qdir20/nqdir30
       DFSTestUtil.createFile(dfs, file2, file2Len, replication, 0);
-      
+
       c = dfs.getContentSummary(quotaDir20);
       assertEquals(c.getSpaceConsumed(), 3 * fileSpace);
       c = dfs.getContentSummary(quotaDir21);
       assertEquals(c.getSpaceConsumed(), 0);
-      
+
       // Reverse: Move /nqdir0/qdir1/qdir20/nqdir30 to /nqdir0/qdir1/qdir21/
       hasException = false;
       try {
@@ -637,39 +725,39 @@ public class TestQuota {
         hasException = true;
       }
       assertTrue(hasException);
-      
+
       // make sure no intermediate directories left by failed rename
       assertFalse(dfs.exists(srcPath));
       // directory should exist
       assertTrue(dfs.exists(dstPath));
-            
+
       // verify space after the failed move
       c = dfs.getContentSummary(quotaDir20);
       assertEquals(c.getSpaceConsumed(), 3 * fileSpace);
       c = dfs.getContentSummary(quotaDir21);
       assertEquals(c.getSpaceConsumed(), 0);
-      
+
       // Test Append :
-      
+
       // verify space quota
       c = dfs.getContentSummary(quotaDir1);
       assertEquals(c.getSpaceQuota(), 4 * fileSpace);
-      
+
       // verify space before append;
       c = dfs.getContentSummary(dstPath);
       assertEquals(c.getSpaceConsumed(), 3 * fileSpace);
-      
+
       OutputStream out = dfs.append(file2);
       // appending 1 fileLen should succeed
       out.write(new byte[fileLen]);
       out.close();
-      
+
       file2Len += fileLen; // after append
-      
+
       // verify space after append;
       c = dfs.getContentSummary(dstPath);
       assertEquals(c.getSpaceConsumed(), 4 * fileSpace);
-      
+
       // now increase the quota for quotaDir1
       dfs.setQuota(quotaDir1, HdfsConstants.QUOTA_DONT_SET, 5 * fileSpace);
       // Now, appending more than 1 fileLen should result in an error
@@ -684,22 +772,22 @@ public class TestQuota {
         IOUtils.closeStream(out);
       }
       assertTrue(hasException);
-      
+
       file2Len += fileLen; // after partial append
-      
+
       // verify space after partial append
       c = dfs.getContentSummary(dstPath);
       assertEquals(c.getSpaceConsumed(), 5 * fileSpace);
-      
+
       // Test set replication :
-      
+
       // first reduce the replication
       dfs.setReplication(file2, (short)(replication-1));
-      
+
       // verify that space is reduced by file2Len
       c = dfs.getContentSummary(dstPath);
       assertEquals(c.getSpaceConsumed(), 5 * fileSpace - file2Len);
-      
+
       // now try to increase the replication and and expect an error.
       hasException = false;
       try {
@@ -712,11 +800,11 @@ public class TestQuota {
       // verify space consumed remains unchanged.
       c = dfs.getContentSummary(dstPath);
       assertEquals(c.getSpaceConsumed(), 5 * fileSpace - file2Len);
-      
+
       // now increase the quota for quotaDir1 and quotaDir20
       dfs.setQuota(quotaDir1, HdfsConstants.QUOTA_DONT_SET, 10 * fileSpace);
       dfs.setQuota(quotaDir20, HdfsConstants.QUOTA_DONT_SET, 10 * fileSpace);
-      
+
       // then increasing replication should be ok.
       dfs.setReplication(file2, (short)(replication+1));
       // verify increase in space
@@ -790,7 +878,7 @@ public class TestQuota {
    * space of the block is used.
    */
   @Test
-  public void testBlockAllocationAdjustsUsageConservatively() 
+  public void testBlockAllocationAdjustsUsageConservatively()
       throws Exception {
     Configuration conf = new HdfsConfiguration();
     final int BLOCK_SIZE = 6 * 1024;
@@ -816,7 +904,7 @@ public class TestQuota {
                                              // repl.
       final int FILE_SIZE = BLOCK_SIZE / 2;
       ContentSummary c;
-      
+
       // Create the directory and set the quota
       assertTrue(fs.mkdirs(dir));
       runCommand(admin, false, "-setSpaceQuota", Integer.toString(QUOTA_SIZE),
@@ -834,7 +922,7 @@ public class TestQuota {
       // used by two files (2 * 3 * 512/2) would fit within the quota (3 * 512)
       // when a block for a file is created the space used is adjusted
       // conservatively (3 * block size, ie assumes a full block is written)
-      // which will violate the quota (3 * block size) since we've already 
+      // which will violate the quota (3 * block size) since we've already
       // used half the quota for the first file.
       try {
         DFSTestUtil.createFile(fs, file2, FILE_SIZE, (short) 3, 1L);
@@ -849,7 +937,7 @@ public class TestQuota {
 
  /**
   * Like the previous test but create many files. This covers bugs where
-  * the quota adjustment is incorrect but it takes many files to accrue 
+  * the quota adjustment is incorrect but it takes many files to accrue
   * a big enough accounting error to violate the quota.
   */
   @Test
@@ -861,7 +949,7 @@ public class TestQuota {
     // Make it relinquish locks. When run serially, the result should
     // be identical.
     conf.setInt(DFSConfigKeys.DFS_CONTENT_SUMMARY_LIMIT_KEY, 2);
-    MiniDFSCluster cluster = 
+    MiniDFSCluster cluster =
       new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
     cluster.waitActive();
     FileSystem fs = cluster.getFileSystem();
@@ -871,7 +959,7 @@ public class TestQuota {
     final String webhdfsuri = WebHdfsFileSystem.SCHEME  + "://" + nnAddr;
     System.out.println("webhdfsuri=" + webhdfsuri);
     final FileSystem webhdfs = new Path(webhdfsuri).getFileSystem(conf);
-    
+
     try {
       Path dir = new Path("/test");
       boolean exceededQuota = false;
@@ -953,4 +1041,19 @@ public class TestQuota {
     }
   }
 
+  /**
+   * Test to all the commands by passing the fully qualified path.
+   */
+  @Test(timeout = 30000)
+  public void testQuotaCommandsWithURI() throws Exception {
+    DFSAdmin dfsAdmin = new DFSAdmin(conf);
+    final Path dir = new Path("/" + this.getClass().getSimpleName(),
+        GenericTestUtils.getMethodName());
+    assertTrue(dfs.mkdirs(dir));
+    runCommand(dfsAdmin, false, "-setQuota", "1000",
+        dfs.getUri() + "/" + dir.toString());
+
+    runCommand(dfsAdmin, false, "-clrQuota",
+        dfs.getUri() + "/" + dir.toString());
+  }
 }


### PR DESCRIPTION
HDFS-12292, HDFS-11432, HDFS-7600, HDFS-11177, HDFS-11011. Support viewfs:// schema path for DfsAdmin commands

HDFS-12292 Federation: Support viewfs:// schema path for DfsAdmin commands. Contributed by Mikhail Erofeev.

(not in upstream)

HDFS-11432. Federation : Support fully qualified path for Quota/Snapshot/cacheadmin/cryptoadmin commands. Contributed by Brahma Reddy Battula.

(cherry picked from commit dcd03df)

HDFS-7600. Refine hdfs admin classes to reuse common code. Contributed by Jing Zhao.

(cherry picked from commit 6f3a63a)

HDFS-11177. 'storagepolicies -getStoragePolicy' command should accept URI based path. (Contributed by Surendra Singh Lilhore)

(cherry picked from commit 4804050)

HDFS-11011. Add unit tests for HDFS command 'dfsadmin -set/clrSpaceQuota'. Contributed by Xiaobing Zhou.

(cherry picked from commit 9a8a386)