### PR TITLE
WIP - [MAPREDUCE-6659] - Mapreduce App master waits long to kill containers on lost nodes.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/event/TaskAttemptEventType.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/event/TaskAttemptEventType.java
@@ -22,6 +22,8 @@ package org.apache.hadoop.mapreduce.v2.app.job.event;
  * Event types handled by TaskAttempt.
  */
 public enum TaskAttemptEventType {
+  //LOST NODEMANAGER
+  TA_LOST_NM,
 
   //Producer:Task
   TA_SCHEDULE,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/event/TaskAttemptKillEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/event/TaskAttemptKillEvent.java
@@ -26,9 +26,14 @@ public class TaskAttemptKillEvent extends TaskAttemptEvent {
   private final String message;
 
   public TaskAttemptKillEvent(TaskAttemptId attemptID,
-      String message) {
-    super(attemptID, TaskAttemptEventType.TA_KILL);
+      String message, boolean isFromLostNode) {
+    super(attemptID, isFromLostNode ? TaskAttemptEventType.TA_LOST_NM : TaskAttemptEventType.TA_KILL);
     this.message = message;
+  }
+
+  public TaskAttemptKillEvent(TaskAttemptId attemptID,
+      String message) {
+    this(attemptID, message, false);
   }
 
   public String getMessage() {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/JobImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/JobImpl.java
@@ -1342,7 +1342,7 @@ public class JobImpl implements org.apache.hadoop.mapreduce.v2.app.job.Job,
           if (TaskType.MAP == id.getTaskId().getTaskType()) {
             // reschedule only map tasks because their outputs maybe unusable
             LOG.info(mesg + ". AttemptId:" + id);
-            eventHandler.handle(new TaskAttemptKillEvent(id, mesg));
+            eventHandler.handle(new TaskAttemptKillEvent(id, mesg, nodeState.isUnusable()));
           }
         }
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/rm/RMContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/rm/RMContainerAllocator.java
@@ -844,7 +844,7 @@ public class RMContainerAllocator extends RMContainerRequestor
                 + taskAttemptNodeId);
             eventHandler.handle(new TaskAttemptKillEvent(tid,
                 "TaskAttempt killed because it ran on unusable node"
-                    + taskAttemptNodeId));
+                    + taskAttemptNodeId, true));
           }
         }
       }


### PR DESCRIPTION
Linked to this internal issue: HDP-7099

The idea of this patch is to directly failed the task running on a lost NM as cleaning it is not possible (the node is not accessible)