### PR TITLE
[YARN-7772] - yarn.nodemanager.container-monitor.procfs-tree.smaps-based-rss.enabled is not taken if process-tree class is not set

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ResourceCalculatorProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ResourceCalculatorProcessTree.java
@@ -214,6 +214,15 @@ public abstract class ResourceCalculatorProcessTree extends Configured {
    */
   public static ResourceCalculatorProcessTree getResourceCalculatorProcessTree(
     String pid, Class<? extends ResourceCalculatorProcessTree> clazz, Configuration conf) {
+    if (clazz == null) {
+      // No class given, try a os specific class
+      if (ProcfsBasedProcessTree.isAvailable()) {
+        clazz = ProcfsBasedProcessTree.class;
+      }
+      if (WindowsBasedProcessTree.isAvailable()) {
+        clazz = WindowsBasedProcessTree.class;
+      }
+    }
 
     if (clazz != null) {
       try {
@@ -224,14 +233,6 @@ public abstract class ResourceCalculatorProcessTree extends Configured {
       } catch(Exception e) {
         throw new RuntimeException(e);
       }
-    }
-
-    // No class given, try a os specific class
-    if (ProcfsBasedProcessTree.isAvailable()) {
-      return new ProcfsBasedProcessTree(pid);
-    }
-    if (WindowsBasedProcessTree.isAvailable()) {
-      return new WindowsBasedProcessTree(pid);
     }
 
     // Not supported on this system.


### PR DESCRIPTION
Currently setConf is not call which leads to parameter
yarn.nodemanager.container-monitor.procfs-tree.smaps-based-rss.enabled not beaing read