### PR TITLE
HDFS-11960. Successfully closed files can stay under-replicated.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3326,7 +3326,8 @@ public class BlockManager implements BlockStatsMXBean {
     // Modify the blocks->datanode map and node's map.
     //
     BlockInfo storedBlock = getStoredBlock(block);
-    if (storedBlock != null) {
+    if (storedBlock != null &&
+        block.getGenerationStamp() == storedBlock.getGenerationStamp()) {
       pendingReplications.decrement(storedBlock, node);
     }
     processAndHandleReportedBlock(storageInfo, block, ReplicaState.FINALIZED,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReplication.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReplication.java
@@ -193,6 +193,8 @@ public class TestPendingReplication {
       // Place into blocksmap with GenerationStamp = 1
       blockInfo.setGenerationStamp(1);
       blocksMap.addBlockCollection(blockInfo, bc);
+      //Save it for later.
+      BlockInfo storedBlock = blockInfo;
 
       assertEquals("Size of pendingReplications ", 1,
           pendingReplications.size());
@@ -239,6 +241,49 @@ public class TestPendingReplication {
       // Verify size of neededReplications is exactly 1.
       assertEquals("size of neededReplications is 1 ", 1,
           neededReplications.size());
+
+      // Verify HDFS-11960
+      // Stop the replication/redundancy monitor
+      BlockManagerTestUtil.stopReplicationThread(blkManager);
+      pendingReplications.clear();
+      // Pick a real node
+      DatanodeDescriptor desc[] = { blkManager.getDatanodeManager().
+          getDatanodes().iterator().next() };
+
+      // Add a stored block to the pendingReconstruction.
+      pendingReplications.increment(storedBlock, desc);
+      assertEquals("Size of pendingReplications ", 1,
+          pendingReplications.size());
+
+      // A received IBR processing calls addBlock(). If the gen stamp in the
+      // report is not the same, it should stay in pending.
+      fsn.writeLock();
+      try {
+        // Use a wrong gen stamp.
+        blkManager.addBlock(desc[0].getStorageInfos()[0],
+            new Block(1, 1, 0), null);
+      } finally {
+        fsn.writeUnlock();
+      }
+
+      // The block should still be pending
+      assertEquals("Size of pendingReplications ", 1,
+          pendingReplications.size());
+
+      // A block report with the correct gen stamp should remove the record
+      // from the pending queue.
+      fsn.writeLock();
+      try {
+        blkManager.addBlock(desc[0].getStorageInfos()[0],
+            new Block(1, 1, 1), null);
+      } finally {
+        fsn.writeUnlock();
+      }
+
+      // The pending queue should be empty.
+      assertEquals("Size of pendingReplications ", 0,
+          pendingReplications.size());
+
     } finally {
       if (cluster != null) {
         cluster.shutdown();


### PR DESCRIPTION
Contributed by Kihwal Lee.

(cherry picked from commit 8f533ca76b3f3592dc8ec6e318382a54becf10f5)
(cherry picked from commit 40e3cd24b068d08be8cf05668290b908f6b43c11)

 Conflicts:
	hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java

Change-Id: I617d15c11184556d1e12f03bac76a196877b6c49
(cherry picked from commit 9bb86f2789f396b216786e619b956cc7d5b6eec9)