### PR TITLE
[YARN-7793] - Lots of parsing error reported on nodemanager after activating yarn.nodemanager.container-monitor.procfs-tree.smaps-based-rss.enabled

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
@@ -93,13 +93,12 @@ public class ProcfsBasedProcessTree extends ResourceCalculatorProcessTree {
 
   public static final String SMAPS = "smaps";
   public static final int KB_TO_BYTES = 1024;
-  private static final String KB = "kB";
   private static final String READ_ONLY_WITH_SHARED_PERMISSION = "r--s";
   private static final String READ_EXECUTE_WITH_SHARED_PERMISSION = "r-xs";
   private static final Pattern ADDRESS_PATTERN = Pattern
     .compile("([[a-f]|(0-9)]*)-([[a-f]|(0-9)]*)(\\s)*([rxwps\\-]*)");
   private static final Pattern MEM_INFO_PATTERN = Pattern
-    .compile("(^[A-Z].*):[\\s ]*(.*)");
+    .compile("(^[A-Z].*):[\\s ]*(\\d+).*");
 
   private boolean smapsEnabled;
 
@@ -795,7 +794,7 @@ public class ProcfsBasedProcessTree extends ResourceCalculatorProcessTree {
           Matcher memInfo = MEM_INFO_PATTERN.matcher(line);
           if (memInfo.find()) {
             String key = memInfo.group(1).trim();
-            String value = memInfo.group(2).replace(KB, "").trim();
+            String value = memInfo.group(2);
             if (LOG.isDebugEnabled()) {
               LOG.debug("MemInfo : " + key + " : Value  : " + value);
             }


### PR DESCRIPTION
Exemple of error message spamming the nodemanager logs:
    ERROR org.apache.hadoop.yarn.util.ProcfsBasedProcessTree: Error in parsing : INVALID : valuerd wr mr mw me ac

This is due to VmFlags: rd ex mr mw me de  line in smaps file