### PR TITLE
Namenode doesn't leave safemode if dfs.namenode.safemode.replication.min set

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -330,6 +330,10 @@ public class BlockManager implements BlockStatsMXBean {
    */
   private final short minReplicationToBeInMaintenance;
 
+  /** Minimum live replicas for calculating safe block count.
+   */
+  private final short minReplicationSafemode;
+
   public BlockManager(final Namesystem namesystem, final FSClusterStats stats,
       final Configuration conf) throws IOException {
     this.namesystem = namesystem;
@@ -438,6 +442,27 @@ public class BlockManager implements BlockStatsMXBean {
           + " = " + defaultReplication);
     }
     this.minReplicationToBeInMaintenance = (short)minMaintenanceR;
+
+    // DFS_NAMENODE_SAFEMODE_REPLICATION_MIN_KEY is an expert level setting,
+    // setting this lower than the min replication is not recommended
+    // and/or dangerous for production setups.
+    // When it's unset, safeReplication will use dfs.namenode.replication.min
+    final int minSafemodeR =
+            conf.getInt(DFSConfigKeys.DFS_NAMENODE_SAFEMODE_REPLICATION_MIN_KEY,
+                    minReplication);
+    if (minSafemodeR < 0) {
+      throw new IOException("Unexpected configuration parameters: "
+              + DFSConfigKeys.DFS_NAMENODE_SAFEMODE_REPLICATION_MIN_KEY
+              + " = " + minSafemodeR + " < 0");
+    }
+    if (minSafemodeR > defaultReplication) {
+      throw new IOException("Unexpected configuration parameters: "
+              + DFSConfigKeys.DFS_NAMENODE_SAFEMODE_REPLICATION_MIN_KEY
+              + " = " + minSafemodeR + " > "
+              + DFSConfigKeys.DFS_REPLICATION_KEY
+              + " = " + defaultReplication);
+    }
+    this.minReplicationSafemode = (short)minMaintenanceR;
 
     this.getBlocksMinBlockSize = conf.getLongBytes(
         DFSConfigKeys.DFS_BALANCER_GETBLOCKS_MIN_BLOCK_SIZE_KEY,
@@ -784,7 +809,7 @@ public class BlockManager implements BlockStatsMXBean {
     // OP_CLOSE edit on the standby).
     namesystem.adjustSafeModeBlockTotals(0, 1);
     namesystem.incrementSafeBlockCount(
-        Math.min(numNodes, minReplication));
+        Math.min(numNodes, minReplicationSafemode));
     
     // replace block in the blocksMap
     return blocksMap.replaceBlock(completeBlock);


### PR DESCRIPTION
When we set dfs.namenode.safemode.replication.min from HDFS-8716 patch
the number of replica for which we will increase the safe block count safe block count
must be equal to dfs.namenode.safemode.replication.min.
When reading modification from edits, the replica nmber for new blocks is set at min(numNodes,
dfs.namenode.replication.min) which is greater than dfs.namenode.safemode.replication.min.
Due to that safe block count never reach number of available blocks and namenode doesn't leave automatically
the safemode