### PR TITLE
[LAKECOMP-498] Exposing scheduler configuration values s.t. they can …

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1010,23 +1010,27 @@ public class ResourceManager extends CompositeService implements Recoverable {
       }
     }
 
+    // Include scheduler config values (if they exist) into the config exposed to the web app
+    Configuration webConf = new Configuration(conf);
+    webConf.addResource(scheduler.getSchedulerConfiguration());
+
     Builder<ApplicationMasterService> builder = 
         WebApps
             .$for("cluster", ApplicationMasterService.class, masterService,
                 "ws")
-            .with(conf)
+            .with(webConf)
             .withHttpSpnegoPrincipalKey(
                 YarnConfiguration.RM_WEBAPP_SPNEGO_USER_NAME_KEY)
             .withHttpSpnegoKeytabKey(
                 YarnConfiguration.RM_WEBAPP_SPNEGO_KEYTAB_FILE_KEY)
             .at(webAppAddress);
-    String proxyHostAndPort = WebAppUtils.getProxyHostAndPort(conf);
-    if(WebAppUtils.getResolvedRMWebAppURLWithoutScheme(conf).
+    String proxyHostAndPort = WebAppUtils.getProxyHostAndPort(webConf);
+    if(WebAppUtils.getResolvedRMWebAppURLWithoutScheme(webConf).
         equals(proxyHostAndPort)) {
-      if (HAUtil.isHAEnabled(conf)) {
-        fetcher = new AppReportFetcher(conf);
+      if (HAUtil.isHAEnabled(webConf)) {
+        fetcher = new AppReportFetcher(webConf);
       } else {
-        fetcher = new AppReportFetcher(conf, getClientRMService());
+        fetcher = new AppReportFetcher(webConf, getClientRMService());
       }
       builder.withServlet(ProxyUriUtils.PROXY_SERVLET_NAME,
           ProxyUriUtils.PROXY_PATH_SPEC, WebAppProxyServlet.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/ResourceScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/ResourceScheduler.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.recovery.Recoverable;
  */
 @LimitedPrivate("yarn")
 @Evolving
-public interface ResourceScheduler extends YarnScheduler, Recoverable {
+public interface ResourceScheduler extends YarnScheduler, Recoverable, SchedulerConfiguration {
 
   /**
    * Set RMContext for <code>ResourceScheduler</code>.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerConfiguration.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager.scheduler;
+
+import org.apache.hadoop.classification.InterfaceAudience.LimitedPrivate;
+import org.apache.hadoop.conf.Configuration;
+
+@LimitedPrivate("yarn")
+public interface SchedulerConfiguration {
+
+  Configuration getSchedulerConfiguration();
+
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -258,6 +258,11 @@ public class CapacityScheduler extends
   }
 
   @Override
+  public Configuration getSchedulerConfiguration() {
+    return conf;
+  }
+
+  @Override
   public synchronized RMContainerTokenSecretManager 
   getContainerTokenSecretManager() {
     return this.rmContext.getContainerTokenSecretManager();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
@@ -258,6 +258,9 @@ public class FairScheduler extends
     return conf;
   }
 
+  @Override
+  public Configuration getSchedulerConfiguration() { return this.conf; }
+
   public int getNumNodesInRack(String rackName) {
     return nodeTracker.nodeCount(rackName);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
@@ -255,6 +255,9 @@ public class FifoScheduler extends
   public synchronized void setConf(Configuration conf) {
     this.conf = conf;
   }
+
+  @Override
+  public Configuration getSchedulerConfiguration() { return this.conf; }
   
   private void validateConf(Configuration conf) {
     // validate scheduler memory allocation setting


### PR DESCRIPTION
…be displayed by generic /conf endpoint; this way, configuration values displayed by the ResourceManager will be complete.