### PR TITLE
[LAKECOMP-498] Exposing scheduler configuration values s.t. they can …

### DIFF
--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/scheduler/ResourceSchedulerWrapper.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/scheduler/ResourceSchedulerWrapper.java
@@ -938,4 +938,11 @@ public class ResourceSchedulerWrapper
       ContainerStatus containerStatus, RMContainerEventType event) {
     // do nothing
   }
+
+  @Override
+  public Configuration getSchedulerConfiguration() {
+    if (scheduler == null)
+      return new Configuration();
+    return scheduler.getSchedulerConfiguration();
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1010,23 +1010,27 @@ public class ResourceManager extends CompositeService implements Recoverable {
       }
     }
 
+    // Include scheduler config values into the config exposed to the web app
+    Configuration webConf = new Configuration(conf);
+    webConf.addResource(scheduler.getSchedulerConfiguration());
+
     Builder<ApplicationMasterService> builder = 
         WebApps
             .$for("cluster", ApplicationMasterService.class, masterService,
                 "ws")
-            .with(conf)
+            .with(webConf)
             .withHttpSpnegoPrincipalKey(
                 YarnConfiguration.RM_WEBAPP_SPNEGO_USER_NAME_KEY)
             .withHttpSpnegoKeytabKey(
                 YarnConfiguration.RM_WEBAPP_SPNEGO_KEYTAB_FILE_KEY)
             .at(webAppAddress);
-    String proxyHostAndPort = WebAppUtils.getProxyHostAndPort(conf);
-    if(WebAppUtils.getResolvedRMWebAppURLWithoutScheme(conf).
+    String proxyHostAndPort = WebAppUtils.getProxyHostAndPort(webConf);
+    if(WebAppUtils.getResolvedRMWebAppURLWithoutScheme(webConf).
         equals(proxyHostAndPort)) {
-      if (HAUtil.isHAEnabled(conf)) {
-        fetcher = new AppReportFetcher(conf);
+      if (HAUtil.isHAEnabled(webConf)) {
+        fetcher = new AppReportFetcher(webConf);
       } else {
-        fetcher = new AppReportFetcher(conf, getClientRMService());
+        fetcher = new AppReportFetcher(webConf, getClientRMService());
       }
       builder.withServlet(ProxyUriUtils.PROXY_SERVLET_NAME,
           ProxyUriUtils.PROXY_PATH_SPEC, WebAppProxyServlet.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/CapacityReservationSystem.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/CapacityReservationSystem.java
@@ -70,7 +70,7 @@ public class CapacityReservationSystem extends AbstractReservationSystem {
   protected Plan initializePlan(String planQueueName) throws YarnException {
     SharingPolicy adPolicy = getAdmissionPolicy(planQueueName);
     String planQueuePath = capScheduler.getQueue(planQueueName).getQueuePath();
-    adPolicy.init(planQueuePath, capScheduler.getConfiguration());
+    adPolicy.init(planQueuePath, capScheduler.getSchedulerConfiguration());
     CSQueue planQueue = capScheduler.getQueue(planQueueName);
     // Calculate the max plan capacity
     Resource minAllocation = capScheduler.getMinimumResourceCapability();
@@ -82,8 +82,9 @@ public class CapacityReservationSystem extends AbstractReservationSystem {
         new InMemoryPlan(capScheduler.getRootQueueMetrics(), adPolicy,
             getAgent(planQueuePath), totCap, planStepSize, rescCalc,
             minAllocation, capScheduler.getMaximumResourceCapability(),
-            planQueueName, getReplanner(planQueuePath), capScheduler
-                .getConfiguration().getMoveOnExpiry(planQueuePath));
+            planQueueName, getReplanner(planQueuePath),
+            ((CapacitySchedulerConfiguration) capScheduler
+                .getSchedulerConfiguration()).getMoveOnExpiry(planQueuePath));
     LOG.info("Intialized plan {0} based on reservable queue {1}",
         plan.toString(), planQueueName);
     return plan;
@@ -92,7 +93,8 @@ public class CapacityReservationSystem extends AbstractReservationSystem {
   @Override
   protected Planner getReplanner(String planQueueName) {
     CapacitySchedulerConfiguration capSchedulerConfig =
-        capScheduler.getConfiguration();
+        (CapacitySchedulerConfiguration) capScheduler
+            .getSchedulerConfiguration();
     String plannerClassName = capSchedulerConfig.getReplanner(planQueueName);
     LOG.info("Using Replanner: " + plannerClassName + " for queue: "
         + planQueueName);
@@ -117,7 +119,8 @@ public class CapacityReservationSystem extends AbstractReservationSystem {
   @Override
   protected ReservationAgent getAgent(String queueName) {
     CapacitySchedulerConfiguration capSchedulerConfig =
-        capScheduler.getConfiguration();
+        (CapacitySchedulerConfiguration) capScheduler
+            .getSchedulerConfiguration();
     String agentClassName = capSchedulerConfig.getReservationAgent(queueName);
     LOG.info("Using Agent: " + agentClassName + " for queue: " + queueName);
     try {
@@ -137,7 +140,8 @@ public class CapacityReservationSystem extends AbstractReservationSystem {
   @Override
   protected SharingPolicy getAdmissionPolicy(String queueName) {
     CapacitySchedulerConfiguration capSchedulerConfig =
-        capScheduler.getConfiguration();
+        (CapacitySchedulerConfiguration) capScheduler
+            .getSchedulerConfiguration();
     String admissionPolicyClassName =
         capSchedulerConfig.getReservationAdmissionPolicy(queueName);
     LOG.info("Using AdmissionPolicy: " + admissionPolicyClassName

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/ResourceScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/ResourceScheduler.java
@@ -33,7 +33,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.recovery.Recoverable;
  */
 @LimitedPrivate("yarn")
 @Evolving
-public interface ResourceScheduler extends YarnScheduler, Recoverable {
+public interface ResourceScheduler
+    extends YarnScheduler, Recoverable, SchedulerConfiguration {
 
   /**
    * Set RMContext for <code>ResourceScheduler</code>.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerConfiguration.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager.scheduler;
+
+import org.apache.hadoop.classification.InterfaceAudience.LimitedPrivate;
+import org.apache.hadoop.conf.Configuration;
+
+@LimitedPrivate("yarn")
+public interface SchedulerConfiguration {
+
+  Configuration getSchedulerConfiguration();
+
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractCSQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractCSQueue.java
@@ -94,16 +94,18 @@ public abstract class AbstractCSQueue implements CSQueue {
     this.parent = parent;
     this.queueName = queueName;
     this.resourceCalculator = cs.getResourceCalculator();
-    
+
+    CapacitySchedulerConfiguration csConf =
+        (CapacitySchedulerConfiguration) cs.getSchedulerConfiguration();
     // must be called after parent and queueName is set
     this.metrics = old != null ? old.getMetrics() :
         QueueMetrics.forQueue(getQueuePath(), parent,
-            cs.getConfiguration().getEnableUserMetrics(),
+            csConf.getEnableUserMetrics(),
             cs.getConf());
     
     // get labels
-    this.accessibleLabels = cs.getConfiguration().getAccessibleNodeLabels(getQueuePath());
-    this.defaultLabelExpression = cs.getConfiguration()
+    this.accessibleLabels = csConf.getAccessibleNodeLabels(getQueuePath());
+    this.defaultLabelExpression = csConf
         .getDefaultNodeLabelExpression(getQueuePath());
 
     // inherit from parent if labels not set
@@ -121,12 +123,12 @@ public abstract class AbstractCSQueue implements CSQueue {
     
     // set capacity by labels
     capacitiyByNodeLabels =
-        cs.getConfiguration().getNodeLabelCapacities(getQueuePath(), accessibleLabels,
+        csConf.getNodeLabelCapacities(getQueuePath(), accessibleLabels,
             labelManager);
 
     // set maximum capacity by labels
     maxCapacityByNodeLabels =
-        cs.getConfiguration().getMaximumNodeLabelCapacities(getQueuePath(),
+        csConf.getMaximumNodeLabelCapacities(getQueuePath(),
             accessibleLabels, labelManager);
     queueEntity = new PrivilegedEntity(EntityType.QUEUE, getQueuePath());
     authorizer = YarnAuthorizationProvider.getInstance(cs.getConf());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -251,9 +251,9 @@ public class CapacityScheduler extends
   public CSQueue getRootQueue() {
     return root;
   }
-  
+
   @Override
-  public CapacitySchedulerConfiguration getConfiguration() {
+  public Configuration getSchedulerConfiguration() {
     return conf;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerContext.java
@@ -20,10 +20,12 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import java.util.Comparator;
 
+import java.util.concurrent.ScheduledExecutorService;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerApp;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerNode;
 import org.apache.hadoop.yarn.server.resourcemanager.security.RMContainerTokenSecretManager;
@@ -32,9 +34,8 @@ import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 /**
  * Read-only interface to {@link CapacityScheduler} context.
  */
-public interface CapacitySchedulerContext {
-  CapacitySchedulerConfiguration getConfiguration();
-  
+public interface CapacitySchedulerContext extends SchedulerConfiguration {
+
   Resource getMinimumResourceCapability();
 
   Resource getMaximumResourceCapability();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
@@ -129,11 +129,14 @@ public class LeafQueue extends AbstractCSQueue {
             Resources.subtract(maximumAllocation, minimumAllocation), 
             maximumAllocation);
 
+    CapacitySchedulerConfiguration csConf =
+        (CapacitySchedulerConfiguration) cs.getSchedulerConfiguration();
+
     float capacity = getCapacityFromConf();
     float absoluteCapacity = parent.getAbsoluteCapacity() * capacity;
 
     float maximumCapacity = 
-        (float)cs.getConfiguration().getMaximumCapacity(getQueuePath()) / 100;
+        (float)csConf.getMaximumCapacity(getQueuePath()) / 100;
     float absoluteMaxCapacity = 
         CSQueueUtils.computeAbsoluteMaximumCapacity(maximumCapacity, parent);
         
@@ -141,20 +144,20 @@ public class LeafQueue extends AbstractCSQueue {
     // max avail value during assignContainers
     absoluteMaxAvailCapacity = absoluteMaxCapacity;
 
-    int userLimit = cs.getConfiguration().getUserLimit(getQueuePath());
-    float userLimitFactor = 
-      cs.getConfiguration().getUserLimitFactor(getQueuePath());
+    int userLimit = csConf.getUserLimit(getQueuePath());
+    float userLimitFactor =
+        csConf.getUserLimitFactor(getQueuePath());
 
     int maxApplications =
-        cs.getConfiguration().getMaximumApplicationsPerQueue(getQueuePath());
+        csConf.getMaximumApplicationsPerQueue(getQueuePath());
     if (maxApplications < 0) {
-      int maxSystemApps = cs.getConfiguration().getMaximumSystemApplications();
+      int maxSystemApps = csConf.getMaximumSystemApplications();
       maxApplications = (int)(maxSystemApps * absoluteCapacity);
     }
     maxApplicationsPerUser = 
       (int)(maxApplications * (userLimit / 100.0f) * userLimitFactor);
 
-    float maxAMResourcePerQueuePercent = cs.getConfiguration()
+    float maxAMResourcePerQueuePercent = csConf
         .getMaximumApplicationMasterResourcePerQueuePercent(getQueuePath());
     int maxActiveApplications = 
         CSQueueUtils.computeMaxActiveApplications(
@@ -170,19 +173,19 @@ public class LeafQueue extends AbstractCSQueue {
         CSQueueUtils.computeMaxActiveApplicationsPerUser(
             maxActiveAppsUsingAbsCap, userLimit, userLimitFactor);
 
-    QueueState state = cs.getConfiguration().getState(getQueuePath());
+    QueueState state = csConf.getState(getQueuePath());
 
-    Map<AccessType, AccessControlList> acls = 
-      cs.getConfiguration().getAcls(getQueuePath());
+    Map<AccessType, AccessControlList> acls =
+        csConf.getAcls(getQueuePath());
 
     setupQueueConfigs(cs.getClusterResource(), capacity, absoluteCapacity,
         maximumCapacity, absoluteMaxCapacity, userLimit, userLimitFactor,
         maxApplications, maxAMResourcePerQueuePercent, maxApplicationsPerUser,
-        maxActiveApplications, maxActiveApplicationsPerUser, state, acls, cs
-            .getConfiguration().getNodeLocalityDelay(), accessibleLabels,
+        maxActiveApplications, maxActiveApplicationsPerUser, state, acls,
+            csConf.getNodeLocalityDelay(), accessibleLabels,
         defaultLabelExpression, this.capacitiyByNodeLabels,
         this.maxCapacityByNodeLabels,
-        cs.getConfiguration().getReservationContinueLook());
+        csConf.getReservationContinueLook());
 
     if(LOG.isDebugEnabled()) {
       LOG.debug("LeafQueue:" + " name=" + queueName
@@ -198,7 +201,9 @@ public class LeafQueue extends AbstractCSQueue {
   
   // externalizing in method, to allow overriding
   protected float getCapacityFromConf() {
-    return (float)scheduler.getConfiguration().getCapacity(getQueuePath()) / 100;
+    CapacitySchedulerConfiguration csConf =
+        (CapacitySchedulerConfiguration) scheduler.getSchedulerConfiguration();
+    return (float)csConf.getCapacity(getQueuePath()) / 100;
   }
 
   protected synchronized void setupQueueConfigs(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ParentQueue.java
@@ -87,7 +87,10 @@ public class ParentQueue extends AbstractCSQueue {
 
     this.rootQueue = (parent == null);
 
-    float rawCapacity = cs.getConfiguration().getCapacity(getQueuePath());
+    CapacitySchedulerConfiguration csConf =
+        (CapacitySchedulerConfiguration) cs.getSchedulerConfiguration();
+
+    float rawCapacity = csConf.getCapacity(getQueuePath());
 
     if (rootQueue &&
         (rawCapacity != CapacitySchedulerConfiguration.MAXIMUM_CAPACITY_VALUE)) {
@@ -102,19 +105,19 @@ public class ParentQueue extends AbstractCSQueue {
     float absoluteCapacity = parentAbsoluteCapacity * capacity; 
 
     float  maximumCapacity =
-      (float) cs.getConfiguration().getMaximumCapacity(getQueuePath()) / 100;
+      (float) csConf.getMaximumCapacity(getQueuePath()) / 100;
     float absoluteMaxCapacity = 
           CSQueueUtils.computeAbsoluteMaximumCapacity(maximumCapacity, parent);
     
-    QueueState state = cs.getConfiguration().getState(getQueuePath());
+    QueueState state = csConf.getState(getQueuePath());
 
-    Map<AccessType, AccessControlList> acls = 
-      cs.getConfiguration().getAcls(getQueuePath());
+    Map<AccessType, AccessControlList> acls =
+        csConf.getAcls(getQueuePath());
 
     setupQueueConfigs(cs.getClusterResource(), capacity, absoluteCapacity,
         maximumCapacity, absoluteMaxCapacity, state, acls, accessibleLabels,
-        defaultLabelExpression, capacitiyByNodeLabels, maxCapacityByNodeLabels, 
-        cs.getConfiguration().getReservationContinueLook());
+        defaultLabelExpression, capacitiyByNodeLabels, maxCapacityByNodeLabels,
+        csConf.getReservationContinueLook());
     
     this.childQueues = new TreeSet<CSQueue>(queueComparator);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/PlanQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/PlanQueue.java
@@ -54,7 +54,8 @@ public class PlanQueue extends ParentQueue {
 
     this.schedulerContext = cs;
     // Set the reservation queue attributes for the Plan
-    CapacitySchedulerConfiguration conf = cs.getConfiguration();
+    CapacitySchedulerConfiguration conf =
+        (CapacitySchedulerConfiguration) cs.getSchedulerConfiguration();
     String queuePath = super.getQueuePath();
     int maxAppsForReservation = conf.getMaximumApplicationsPerQueue(queuePath);
     showReservationsAsQueues = conf.getShowReservationAsQueues(queuePath);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ReservationQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ReservationQueue.java
@@ -44,7 +44,8 @@ public class ReservationQueue extends LeafQueue {
   public ReservationQueue(CapacitySchedulerContext cs, String queueName,
       PlanQueue parent) throws IOException {
     super(cs, queueName, parent, null);
-    maxSystemApps = cs.getConfiguration().getMaximumSystemApplications();
+    maxSystemApps = ((CapacitySchedulerConfiguration) cs
+        .getSchedulerConfiguration()).getMaximumSystemApplications();
     // the following parameters are common to all reservation in the plan
     updateQuotas(parent.getUserLimitForReservation(),
         parent.getUserLimitFactor(),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSPreemptionThread.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSPreemptionThread.java
@@ -50,7 +50,8 @@ class FSPreemptionThread extends Thread {
     setName("FSPreemptionThread");
     this.scheduler = scheduler;
     this.context = scheduler.getContext();
-    FairSchedulerConfiguration fsConf = scheduler.getConf();
+    FairSchedulerConfiguration fsConf =
+        (FairSchedulerConfiguration) scheduler.getSchedulerConfiguration();
     context.setPreemptionEnabled();
     context.setPreemptionUtilizationThreshold(
         fsConf.getPreemptionUtilizationThreshold());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSQueue.java
@@ -69,7 +69,9 @@ public abstract class FSQueue implements Queue, Schedulable {
   public FSQueue(String name, FairScheduler scheduler, FSParentQueue parent) {
     this.name = name;
     this.scheduler = scheduler;
-    this.metrics = FSQueueMetrics.forQueue(getName(), parent, true, scheduler.getConf());
+    this.metrics = FSQueueMetrics
+        .forQueue(getName(), parent,
+            true, scheduler.getSchedulerConfiguration());
     metrics.setMinShare(getMinShare());
     metrics.setMaxShare(getMaxShare());
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
@@ -254,9 +254,8 @@ public class FairScheduler extends
     }
   }
 
-  public FairSchedulerConfiguration getConf() {
-    return conf;
-  }
+  @Override
+  public Configuration getSchedulerConfiguration() { return conf; }
 
   public int getNumNodesInRack(String rackName) {
     return nodeTracker.nodeCount(rackName);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
@@ -255,6 +255,12 @@ public class FifoScheduler extends
   public synchronized void setConf(Configuration conf) {
     this.conf = conf;
   }
+
+  @Override
+  public Configuration getSchedulerConfiguration() {
+    // no scheduler-specific configuration is loaded
+    return new Configuration();
+  }
   
   private void validateConf(Configuration conf) {
     // validate scheduler memory allocation setting

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMAdminService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMAdminService.java
@@ -116,11 +116,13 @@ public class TestRMAdminService {
 
     CapacityScheduler cs =
         (CapacityScheduler) rm.getRMContext().getScheduler();
-    int maxAppsBefore = cs.getConfiguration().getMaximumSystemApplications();
+    CapacitySchedulerConfiguration csConf =
+        (CapacitySchedulerConfiguration) cs.getSchedulerConfiguration();
+    int maxAppsBefore = csConf.getMaximumSystemApplications();
 
     try {
       rm.adminService.refreshQueues(RefreshQueuesRequest.newInstance());
-      Assert.assertEquals(maxAppsBefore, cs.getConfiguration()
+      Assert.assertEquals(maxAppsBefore, csConf
           .getMaximumSystemApplications());
     } catch (Exception ex) {
       fail("Using localConfigurationProvider. Should not get any exception.");
@@ -146,7 +148,9 @@ public class TestRMAdminService {
 
     CapacityScheduler cs =
         (CapacityScheduler) rm.getRMContext().getScheduler();
-    int maxAppsBefore = cs.getConfiguration().getMaximumSystemApplications();
+    int maxAppsBefore =
+        ((CapacitySchedulerConfiguration) cs.getSchedulerConfiguration())
+            .getMaximumSystemApplications();
 
     CapacitySchedulerConfiguration csConf =
         new CapacitySchedulerConfiguration();
@@ -155,7 +159,9 @@ public class TestRMAdminService {
 
     rm.adminService.refreshQueues(RefreshQueuesRequest.newInstance());
 
-    int maxAppsAfter = cs.getConfiguration().getMaximumSystemApplications();
+    int maxAppsAfter =
+        ((CapacitySchedulerConfiguration) cs.getSchedulerConfiguration())
+            .getMaximumSystemApplications();
     Assert.assertEquals(maxAppsAfter, 5000);
     Assert.assertTrue(maxAppsAfter != maxAppsBefore);
   }
@@ -567,15 +573,15 @@ public class TestRMAdminService {
       rm1.adminService.refreshQueues(RefreshQueuesRequest.newInstance());
 
       int maxApps =
-          ((CapacityScheduler) rm1.getRMContext().getScheduler())
-              .getConfiguration().getMaximumSystemApplications();
+          ((CapacitySchedulerConfiguration) rm1.getRMContext().getScheduler()
+              .getSchedulerConfiguration()).getMaximumSystemApplications();
       Assert.assertEquals(maxApps, 5000);
 
       // Before failover happens, the maxApps is
       // still the default value on the standby rm : rm2
       int maxAppsBeforeFailOver =
-          ((CapacityScheduler) rm2.getRMContext().getScheduler())
-              .getConfiguration().getMaximumSystemApplications();
+          ((CapacitySchedulerConfiguration) rm2.getRMContext().getScheduler()
+              .getSchedulerConfiguration()).getMaximumSystemApplications();
       Assert.assertEquals(maxAppsBeforeFailOver, 10000);
 
       // Do the failover
@@ -587,8 +593,8 @@ public class TestRMAdminService {
           == HAServiceState.ACTIVE);
 
       int maxAppsAfter =
-          ((CapacityScheduler) rm2.getRMContext().getScheduler())
-              .getConfiguration().getMaximumSystemApplications();
+          ((CapacitySchedulerConfiguration) rm2.getRMContext().getScheduler()
+              .getSchedulerConfiguration()).getMaximumSystemApplications();
 
       Assert.assertEquals(maxAppsAfter, 5000);
     } finally {
@@ -697,7 +703,7 @@ public class TestRMAdminService {
       // validate values for queue configuration
       CapacityScheduler cs =
           (CapacityScheduler) resourceManager.getRMContext().getScheduler();
-      int maxAppsAfter = cs.getConfiguration().getMaximumSystemApplications();
+      int maxAppsAfter = ((CapacitySchedulerConfiguration) cs.getSchedulerConfiguration()).getMaximumSystemApplications();
       Assert.assertEquals(maxAppsAfter, 5000);
 
       // verify service Acls for AdminService

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestCapacityOverTimePolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestCapacityOverTimePolicy.java
@@ -76,7 +76,8 @@ public class TestCapacityOverTimePolicy {
     ReservationSystemTestUtil testUtil = new ReservationSystemTestUtil();
     CapacityScheduler scheduler = testUtil.mockCapacityScheduler(totCont);
     String reservationQ = testUtil.getFullReservationQueueName();
-    CapacitySchedulerConfiguration capConf = scheduler.getConfiguration();
+    CapacitySchedulerConfiguration capConf =
+        (CapacitySchedulerConfiguration) scheduler.getSchedulerConfiguration();
     capConf.setReservationWindow(reservationQ, timeWindow);
     capConf.setInstantaneousMaxCapacity(reservationQ, instConstraint);
     capConf.setAverageCapacity(reservationQ, avgConstraint);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestCapacityReservationSystem.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestCapacityReservationSystem.java
@@ -69,11 +69,13 @@ public class TestCapacityReservationSystem {
     }
     CapacityReservationSystem reservationSystem =
         new CapacityReservationSystem();
-    CapacitySchedulerConfiguration conf = capScheduler.getConfiguration();
+    CapacitySchedulerConfiguration conf =
+        (CapacitySchedulerConfiguration) capScheduler
+            .getSchedulerConfiguration();
     RMContext mockContext = capScheduler.getRMContext();
     reservationSystem.setRMContext(mockContext);
     try {
-      reservationSystem.reinitialize(capScheduler.getConfiguration(),
+      reservationSystem.reinitialize(capScheduler.getSchedulerConfiguration(),
           mockContext);
     } catch (YarnException e) {
       Assert.fail(e.getMessage());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestCapacitySchedulerPlanFollower.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestCapacitySchedulerPlanFollower.java
@@ -104,7 +104,8 @@ public class TestCapacitySchedulerPlanFollower {
     scheduler.setConf(csConf);
 
     csContext = mock(CapacitySchedulerContext.class);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getConf()).thenReturn(csConf);
     when(csContext.getMinimumResourceCapability()).thenReturn(minAlloc);
     when(csContext.getMaximumResourceCapability()).thenReturn(maxAlloc);
@@ -133,7 +134,8 @@ public class TestCapacitySchedulerPlanFollower {
     mAgent = mock(ReservationAgent.class);
 
     String reservationQ = testUtil.getFullReservationQueueName();
-    CapacitySchedulerConfiguration csConf = scheduler.getConfiguration();
+    CapacitySchedulerConfiguration csConf =
+        (CapacitySchedulerConfiguration) scheduler.getSchedulerConfiguration();
     csConf.setReservationWindow(reservationQ, 20L);
     csConf.setMaximumCapacity(reservationQ, 40);
     csConf.setAverageCapacity(reservationQ, 20);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestGreedyReservationAgent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestGreedyReservationAgent.java
@@ -73,7 +73,8 @@ public class TestGreedyReservationAgent {
     ReservationSystemTestUtil testUtil = new ReservationSystemTestUtil();
     CapacityScheduler scheduler = testUtil.mockCapacityScheduler(125);
     String reservationQ = testUtil.getFullReservationQueueName();
-    CapacitySchedulerConfiguration capConf = scheduler.getConfiguration();
+    CapacitySchedulerConfiguration capConf =
+        (CapacitySchedulerConfiguration) scheduler.getSchedulerConfiguration();
     capConf.setReservationWindow(reservationQ, timeWindow);
     capConf.setMaximumCapacity(reservationQ, 100);
     capConf.setAverageCapacity(reservationQ, 100);
@@ -549,7 +550,8 @@ public class TestGreedyReservationAgent {
     ReservationSystemTestUtil testUtil = new ReservationSystemTestUtil();
     CapacityScheduler scheduler = testUtil.mockCapacityScheduler(500 * 100);
     String reservationQ = testUtil.getFullReservationQueueName();
-    CapacitySchedulerConfiguration capConf = scheduler.getConfiguration();
+    CapacitySchedulerConfiguration capConf =
+        (CapacitySchedulerConfiguration) scheduler.getSchedulerConfiguration();
     capConf.setReservationWindow(reservationQ, timeWindow);
     capConf.setMaximumCapacity(reservationQ, 100);
     capConf.setAverageCapacity(reservationQ, 100);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestNoOverCommitPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestNoOverCommitPolicy.java
@@ -62,7 +62,8 @@ public class TestNoOverCommitPolicy {
     ReservationSystemTestUtil testUtil = new ReservationSystemTestUtil();
     CapacityScheduler scheduler = testUtil.mockCapacityScheduler(totCont);
     String reservationQ = testUtil.getFullReservationQueueName();
-    CapacitySchedulerConfiguration capConf = scheduler.getConfiguration();
+    CapacitySchedulerConfiguration capConf =
+        (CapacitySchedulerConfiguration) scheduler.getSchedulerConfiguration();
     NoOverCommitPolicy policy = new NoOverCommitPolicy();
     policy.init(reservationQ, capConf);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestApplicationLimits.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestApplicationLimits.java
@@ -86,7 +86,8 @@ public class TestApplicationLimits {
 
 
     CapacitySchedulerContext csContext = mock(CapacitySchedulerContext.class);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getConf()).thenReturn(conf);
     when(csContext.getMinimumResourceCapability()).
         thenReturn(Resources.createResource(GB, 1));
@@ -164,7 +165,8 @@ public class TestApplicationLimits {
     YarnConfiguration conf = new YarnConfiguration();
     
     CapacitySchedulerContext csContext = mock(CapacitySchedulerContext.class);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getConf()).thenReturn(conf);
     when(csContext.getMinimumResourceCapability()).
         thenReturn(Resources.createResource(GB, 1));
@@ -478,7 +480,8 @@ public class TestApplicationLimits {
     YarnConfiguration conf = new YarnConfiguration();
     
     CapacitySchedulerContext csContext = mock(CapacitySchedulerContext.class);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getConf()).thenReturn(conf);
     when(csContext.getMinimumResourceCapability()).
         thenReturn(Resources.createResource(GB));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCSQueueUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCSQueueUtils.java
@@ -62,7 +62,8 @@ public class TestCSQueueUtils {
   
     CapacitySchedulerContext csContext = mock(CapacitySchedulerContext.class);
     when(csContext.getConf()).thenReturn(conf);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getClusterResource()).thenReturn(clusterResource);
     when(csContext.getResourceCalculator()).thenReturn(resourceCalculator);
     when(csContext.getMinimumResourceCapability()).
@@ -105,7 +106,8 @@ public class TestCSQueueUtils {
     
     CapacitySchedulerContext csContext = mock(CapacitySchedulerContext.class);
     when(csContext.getConf()).thenReturn(conf);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getClusterResource()).thenReturn(clusterResource);
     when(csContext.getResourceCalculator()).thenReturn(resourceCalculator);
     when(csContext.getMinimumResourceCapability()).
@@ -151,7 +153,8 @@ public class TestCSQueueUtils {
     
     CapacitySchedulerContext csContext = mock(CapacitySchedulerContext.class);
     when(csContext.getConf()).thenReturn(conf);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getClusterResource()).thenReturn(clusterResource);
     when(csContext.getResourceCalculator()).thenReturn(resourceCalculator);
     when(csContext.getMinimumResourceCapability()).

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerDynamicBehavior.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerDynamicBehavior.java
@@ -92,7 +92,8 @@ public class TestCapacitySchedulerDynamicBehavior {
     tcs.checkQueueCapacities(cs, A_CAPACITY, B_CAPACITY);
 
     // Reinitialize and verify all dynamic queued survived
-    CapacitySchedulerConfiguration conf = cs.getConfiguration();
+    CapacitySchedulerConfiguration conf =
+        (CapacitySchedulerConfiguration) cs.getSchedulerConfiguration();
     conf.setCapacity(A, 80f);
     conf.setCapacity(B, 20f);
     cs.reinitialize(conf, rm.getRMContext());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestChildQueueOrder.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestChildQueueOrder.java
@@ -86,7 +86,8 @@ public class TestChildQueueOrder {
 
     csContext = mock(CapacitySchedulerContext.class);
     when(csContext.getConf()).thenReturn(conf);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getMinimumResourceCapability()).thenReturn(
         Resources.createResource(GB, 1));
     when(csContext.getMaximumResourceCapability()).thenReturn(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
@@ -133,7 +133,8 @@ public class TestLeafQueue {
     cs.setConf(conf);
 
     csContext = mock(CapacitySchedulerContext.class);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getConf()).thenReturn(conf);
     when(csContext.getMinimumResourceCapability()).
         thenReturn(Resources.createResource(GB, 1));
@@ -2328,7 +2329,8 @@ public class TestLeafQueue {
   private CapacitySchedulerContext mockCSContext(
       CapacitySchedulerConfiguration csConf, Resource clusterResource) {
     CapacitySchedulerContext csContext = mock(CapacitySchedulerContext.class);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getConf()).thenReturn(new YarnConfiguration());
     when(csContext.getResourceCalculator()).thenReturn(resourceCalculator);
     when(csContext.getClusterResource()).thenReturn(clusterResource);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestParentQueue.java
@@ -82,7 +82,8 @@ public class TestParentQueue {
     
     csContext = mock(CapacitySchedulerContext.class);
     when(csContext.getConf()).thenReturn(conf);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getMinimumResourceCapability()).thenReturn(
         Resources.createResource(GB, 1));
     when(csContext.getMaximumResourceCapability()).thenReturn(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestReservationQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestReservationQueue.java
@@ -50,7 +50,8 @@ public class TestReservationQueue {
     csConf = new CapacitySchedulerConfiguration();
     YarnConfiguration conf = new YarnConfiguration();
     csContext = mock(CapacitySchedulerContext.class);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getConf()).thenReturn(conf);
     when(csContext.getMinimumResourceCapability()).thenReturn(
         Resources.createResource(GB, 1));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestReservations.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestReservations.java
@@ -111,7 +111,8 @@ public class TestReservations {
     cs.setConf(conf);
 
     csContext = mock(CapacitySchedulerContext.class);
-    when(csContext.getConfiguration()).thenReturn(csConf);
+    when((CapacitySchedulerConfiguration) csContext
+        .getSchedulerConfiguration()).thenReturn(csConf);
     when(csContext.getConf()).thenReturn(conf);
     when(csContext.getMinimumResourceCapability()).thenReturn(
         Resources.createResource(GB, 1));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestContinuousScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestContinuousScheduling.java
@@ -386,6 +386,7 @@ public class TestContinuousScheduling extends FairSchedulerTestBase {
 
   private void triggerSchedulingAttempt() throws InterruptedException {
     Thread.sleep(
-        2 * scheduler.getConf().getContinuousSchedulingSleepMs());
+        2 * ((FairSchedulerConfiguration) scheduler
+            .getSchedulerConfiguration()).getContinuousSchedulingSleepMs());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFSParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFSParentQueue.java
@@ -41,7 +41,8 @@ public class TestFSParentQueue {
     FairScheduler scheduler = mock(FairScheduler.class);
     AllocationConfiguration allocConf = new AllocationConfiguration(conf);
     when(scheduler.getAllocationConfiguration()).thenReturn(allocConf);
-    when(scheduler.getConf()).thenReturn(conf);
+    when((FairSchedulerConfiguration) scheduler
+        .getSchedulerConfiguration()).thenReturn(conf);
     SystemClock clock = new SystemClock();
     when(scheduler.getClock()).thenReturn(clock);
     notEmptyQueues = new HashSet<FSQueue>();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestMaxRunningAppsEnforcer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestMaxRunningAppsEnforcer.java
@@ -50,8 +50,8 @@ public class TestMaxRunningAppsEnforcer {
     Configuration conf = new Configuration();
     clock = new ControlledClock();
     scheduler = mock(FairScheduler.class);
-    when(scheduler.getConf()).thenReturn(
-        new FairSchedulerConfiguration(conf));
+    when((FairSchedulerConfiguration) scheduler.getSchedulerConfiguration())
+        .thenReturn(new FairSchedulerConfiguration(conf));
     when(scheduler.getClock()).thenReturn(clock);
     AllocationConfiguration allocConf = new AllocationConfiguration(
         conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueueManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueueManager.java
@@ -51,7 +51,8 @@ public class TestQueueManager {
     allocConf.configuredQueues.get(FSQueueType.PARENT).add("root.test.childB");
 
     when(scheduler.getAllocationConfiguration()).thenReturn(allocConf);
-    when(scheduler.getConf()).thenReturn(conf);
+    when((FairSchedulerConfiguration) scheduler
+        .getSchedulerConfiguration()).thenReturn(conf);
 
     SystemClock clock = new SystemClock();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/TestFairSchedulerQueueInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/TestFairSchedulerQueueInfo.java
@@ -41,7 +41,8 @@ public class TestFairSchedulerQueueInfo {
     FairScheduler scheduler = mock(FairScheduler.class);
     AllocationConfiguration allocConf = new AllocationConfiguration(conf);
     when(scheduler.getAllocationConfiguration()).thenReturn(allocConf);
-    when(scheduler.getConf()).thenReturn(conf);
+    when((FairSchedulerConfiguration) scheduler
+        .getSchedulerConfiguration()).thenReturn(conf);
     when(scheduler.getClusterResource()).thenReturn(Resource.newInstance(1, 1));
     SystemClock clock = new SystemClock();
     when(scheduler.getClock()).thenReturn(clock);


### PR DESCRIPTION
…be displayed by generic /conf endpoint.  Introducing a bit more consistency to the scheduler implementations.