### PR TITLE
Bug fix: HADOOP-15639

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GenericOptionsParser.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GenericOptionsParser.java
@@ -291,10 +291,10 @@ public class GenericOptionsParser {
       //setting libjars in client classpath
       URL[] libjars = getLibJars(conf);
       if(libjars!=null && libjars.length>0) {
-        conf.setClassLoader(new URLClassLoader(libjars, conf.getClassLoader()));
-        Thread.currentThread().setContextClassLoader(
-            new URLClassLoader(libjars, 
-                Thread.currentThread().getContextClassLoader()));
+        ClassLoader libClassLoader = new URLClassLoader(libjars,
+                Thread.currentThread().getContextClassLoader());
+        conf.setClassLoader(libClassLoader);
+        Thread.currentThread().setContextClassLoader(libClassLoader);
       }
     }
     if (line.hasOption("files")) {


### PR DESCRIPTION
The classloader in conf should be consistent with the thread
context classloader. Otherwise the same class can be loaded twice.

See https://issues.apache.org/jira/browse/HADOOP-15639