### PR TITLE
RequestHedgingProxyProvider : Fix NullPointerException while failing over

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/RequestHedgingProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/RequestHedgingProxyProvider.java
@@ -216,8 +216,10 @@ public class RequestHedgingProxyProvider<T> extends
 
   @Override
   public synchronized void performFailover(T currentProxy) {
-    toIgnore = successfulProxy.proxyInfo;
-    successfulProxy = null;
+    if(successfulProxy != null) {
+      toIgnore = successfulProxy.proxyInfo;
+      successfulProxy = null;
+    }
   }
 
   /**


### PR DESCRIPTION
If no successfulProxy exists at the failover time, NullPointerException is raised