### PR TITLE
[HDP-8477] Remove exception trace from info logs

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryInvocationHandler.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryInvocationHandler.java
@@ -228,7 +228,7 @@ public class RetryInvocationHandler<T> implements RpcInvocationHandler {
       if (retryInfo.action.reason != null) {
         LOG.warn("Exception while invoking "
             + proxyDescriptor.getProxyInfo().getString(method.getName())
-            + ". Not retrying because " + retryInfo.action.reason, ex);
+            + ". Not retrying because " + retryInfo.action.reason);
       }
       throw retryInfo.getFailException();
     }
@@ -256,27 +256,23 @@ public class RetryInvocationHandler<T> implements RpcInvocationHandler {
   }
 
   private void log(final Method method, final boolean isFailover,
-      final int failovers, final long delay, final Exception ex) {
+                   final int failovers, final long delay, final Exception ex) {
     // log info if this has made some successful calls or
     // this is not the first failover
-    final boolean info = hasMadeASuccessfulCall || failovers != 0;
-    if (!info && !LOG.isDebugEnabled()) {
-      return;
-    }
-
-    final StringBuilder b = new StringBuilder()
-        .append("Exception while invoking ")
-        .append(proxyDescriptor.getProxyInfo().getString(method.getName()));
+    final StringBuilder b =
+        new StringBuilder()
+            .append("Exception while invoking ")
+            .append(proxyDescriptor.getProxyInfo().getString(method.getName()));
     if (failovers > 0) {
       b.append(" after ").append(failovers).append(" failover attempts");
     }
-    b.append(isFailover? ". Trying to failover ": ". Retrying ");
-    b.append(delay > 0? "after sleeping for " + delay + "ms.": "immediately.");
+    b.append(isFailover ? ". Trying to failover " : ". Retrying ")
+        .append(delay > 0 ? "after sleeping for " + delay + "ms." : "immediately.");
 
-    if (info) {
-      LOG.info(b.toString(), ex);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(b.append(" Reason: ").toString(), ex);
     } else {
-      LOG.debug(b.toString(), ex);
+      LOG.warn(b.toString());
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -854,7 +854,7 @@ public class Client {
       if (action.action == RetryAction.RetryDecision.FAIL) {
         if (action.reason != null) {
           LOG.warn("Failed to connect to server: " + server + ": "
-              + action.reason, ioe);
+              + action.reason);
         }
         throw ioe;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/RequestHedgingProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/RequestHedgingProxyProvider.java
@@ -234,8 +234,6 @@ public class RequestHedgingProxyProvider<T> extends
         LOG.debug("Invocation returned standby exception on [" +
             proxyInfo + "]");
       }
-    } else {
-      LOG.warn("Invocation returned exception on [" + proxyInfo + "]");
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/RequestHedgingProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/RequestHedgingProxyProvider.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * outstanding requests to other proxies are immediately cancelled.
  */
 public class RequestHedgingProxyProvider<T> extends
-        ConfiguredFailoverProxyProvider<T> {
+    ConfiguredFailoverProxyProvider<T> {
 
   public static final Logger LOG =
       LoggerFactory.getLogger(RequestHedgingProxyProvider.class);
@@ -58,7 +58,7 @@ public class RequestHedgingProxyProvider<T> extends
     final Map<String, ProxyInfo<T>> targetProxies;
 
     public RequestHedgingInvocationHandler(
-            Map<String, ProxyInfo<T>> targetProxies) {
+        Map<String, ProxyInfo<T>> targetProxies) {
       this.targetProxies = new HashMap<>(targetProxies);
     }
 
@@ -76,28 +76,35 @@ public class RequestHedgingProxyProvider<T> extends
     @Override
     public Object
     invoke(Object proxy, final Method method, final Object[] args)
-            throws Throwable {
+        throws Throwable {
       Map<Future<Object>, ProxyInfo<T>> proxyMap = new HashMap<>();
       int numAttempts = 0;
 
       ExecutorService executor = null;
       CompletionService<Object> completionService;
-      try {
-        targetProxies.remove(toIgnore);
+      Map<String, Exception> badResults = new HashMap<>();
 
+      try {
         ProxyInfo<T> targetProxy = getSuccessfulOrLeftProxy();
-        if(targetProxy != null){
-          return invokeMethodOnGivenProxy(targetProxy, method, args);
+        if (targetProxy != null) {
+          try {
+            return invokeMethodOnGivenProxy(targetProxy, method, args);
+          } catch (Exception ex) {
+            logProxyException(ex, targetProxy.proxyInfo);
+            badResults.put(targetProxy.proxyInfo, ex);
+          }
         }
         executor = Executors.newFixedThreadPool(proxies.size());
         completionService = new ExecutorCompletionService<>(executor);
         for (final Map.Entry<String, ProxyInfo<T>> pEntry :
-                targetProxies.entrySet()) {
+            targetProxies.entrySet()) {
           Callable<Object> c = new Callable<Object>() {
             @Override
             public Object call() throws Exception {
-              LOG.trace("Invoking method {} on proxy {}", method,
-                  pEntry.getValue().proxyInfo);
+              if (LOG.isTraceEnabled()) {
+                LOG.trace("Invoking method {} on proxy {}", method,
+                    pEntry.getValue().proxyInfo);
+              }
               return method.invoke(pEntry.getValue().proxy, args);
             }
           };
@@ -105,21 +112,25 @@ public class RequestHedgingProxyProvider<T> extends
           numAttempts++;
         }
 
-        Map<String, Exception> badResults = new HashMap<>();
         while (numAttempts > 0) {
           Future<Object> callResultFuture = completionService.take();
           Object retVal;
           try {
             retVal = callResultFuture.get();
             successfulProxy = proxyMap.get(callResultFuture);
-            LOG.debug("Invocation successful on [{}]",
-                successfulProxy.proxyInfo);
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("Invocation successful on :[{}], while invoking: [{}], with args: [{}]",
+                  successfulProxy.proxyInfo, method.toString(), args);
+            }
             return retVal;
           } catch (Exception ex) {
             ProxyInfo<T> tProxyInfo = proxyMap.get(callResultFuture);
             logProxyException(ex, tProxyInfo.proxyInfo);
             badResults.put(tProxyInfo.proxyInfo, unwrapException(ex));
-            LOG.trace("Unsuccessful invocation on [{}]", tProxyInfo.proxyInfo);
+            if (LOG.isTraceEnabled()) {
+              LOG.trace("Unsuccessful invocation on :[{}], while invoking: [{}], with args: [{}]",
+                  tProxyInfo.proxyInfo, method.toString(), args);
+            }
             numAttempts--;
           }
         }
@@ -138,41 +149,45 @@ public class RequestHedgingProxyProvider<T> extends
         }
       }
     }
-      /**
-       * Handle the operation on the given target proxy in params
-       *
-       * @param proxyInfo
-       * @param method
-       * @param args
-       *
-       * @throws Exception
-       */
-      private Object
-      invokeMethodOnGivenProxy(ProxyInfo<T> proxyInfo, Method method,
-                              final Object[] args) throws Exception{
-           try{
-               return method.invoke(proxyInfo.proxy, args);
-           } catch (Exception e){
-               throw unwrapException(e);
-           }
+
+    /**
+     * Handle the operation on the given target proxy in params
+     *
+     * @param proxyInfo
+     * @param method
+     * @param args
+     * @throws Exception
+     */
+    private Object
+    invokeMethodOnGivenProxy(ProxyInfo<T> proxyInfo, Method method,
+                             final Object[] args) throws Exception {
+      try {
+        return method.invoke(proxyInfo.proxy, args);
+      } catch (Exception e) {
+        throw unwrapException(e);
       }
+    }
 
     /**
      * Get the successful/Left proxy
-     *
+     * <p>
      * If a proxy has failed, we, either, return the successful one, or the one not yet tested.
      * return null if none of them exists.
      *
      * @return proxy ProxyInfo
      */
-    private ProxyInfo<T> getSuccessfulOrLeftProxy(){
+    private ProxyInfo<T> getSuccessfulOrLeftProxy() {
       // Optimization : if only 2 proxies are configured and one had failed
       // over, then we dont need to create a threadpool etc.
-      if (successfulProxy != null){
+      if (successfulProxy != null) {
         return successfulProxy;
       }
-      if (targetProxies.size() == 1) {
-        return targetProxies.values().iterator().next();
+      if (toIgnore != null && targetProxies.size() == 2) {
+        for (final Map.Entry<String, ProxyInfo<T>> entry : targetProxies.entrySet()) {
+          if (entry.getKey() != toIgnore) {
+            return entry.getValue();
+          }
+        }
       }
       return null;
     }
@@ -182,7 +197,7 @@ public class RequestHedgingProxyProvider<T> extends
   private volatile String toIgnore = null;
 
   public RequestHedgingProxyProvider(
-          Configuration conf, URI uri, Class<T> xface) {
+      Configuration conf, URI uri, Class<T> xface) {
     this(conf, uri, xface, new DefaultProxyFactory<T>());
   }
 
@@ -208,15 +223,15 @@ public class RequestHedgingProxyProvider<T> extends
     }
     combinedInfo.append(']');
     T wrappedProxy = (T) Proxy.newProxyInstance(
-            RequestHedgingInvocationHandler.class.getClassLoader(),
-            new Class<?>[]{xface},
-            new RequestHedgingInvocationHandler(targetProxyInfos));
+        RequestHedgingInvocationHandler.class.getClassLoader(),
+        new Class<?>[]{xface},
+        new RequestHedgingInvocationHandler(targetProxyInfos));
     return new ProxyInfo<T>(wrappedProxy, combinedInfo.toString());
   }
 
   @Override
   public synchronized void performFailover(T currentProxy) {
-    if(successfulProxy != null) {
+    if (successfulProxy != null) {
       toIgnore = successfulProxy.proxyInfo;
       successfulProxy = null;
     }
@@ -225,7 +240,8 @@ public class RequestHedgingProxyProvider<T> extends
   /**
    * Check the exception returned by the proxy log a warning message if it's
    * not a StandbyException (expected exception).
-   * @param ex Exception to evaluate.
+   *
+   * @param ex        Exception to evaluate.
    * @param proxyInfo Information of the proxy reporting the exception.
    */
   private void logProxyException(Exception ex, String proxyInfo) {
@@ -239,6 +255,7 @@ public class RequestHedgingProxyProvider<T> extends
 
   /**
    * Check if the returned exception is caused by an standby namenode.
+   *
    * @param ex Exception to check.
    * @return If the exception is caused by an standby namenode.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestRequestHedgingProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestRequestHedgingProxyProvider.java
@@ -205,14 +205,14 @@ public class TestRequestHedgingProxyProvider {
     Assert.assertEquals(2, stats[0]);
 
     // Counter should update only once
-    Assert.assertEquals(5, counter.get());
+    Assert.assertEquals(7, counter.get());
 
     stats = provider.getProxy().proxy.getStats();
     Assert.assertTrue(stats.length == 1);
     Assert.assertEquals(2, stats[0]);
 
     // Counter updates only once now
-    Assert.assertEquals(6, counter.get());
+    Assert.assertEquals(8, counter.get());
 
     // Flip back to old active.. so now this should fail
     isGood[0] = 1;
@@ -223,7 +223,7 @@ public class TestRequestHedgingProxyProvider {
       Assert.assertTrue(ex instanceof IOException);
     }
 
-    Assert.assertEquals(7, counter.get());
+    Assert.assertEquals(9, counter.get());
 
     provider.performFailover(provider.getProxy().proxy);
     stats = provider.getProxy().proxy.getStats();
@@ -289,10 +289,8 @@ public class TestRequestHedgingProxyProvider {
     Mockito.verify(goodMock).getStats();
     Mockito.verify(worseMock).getStats();
 
-    stats = provider.getProxy().proxy.getStats();
-    Assert.assertTrue(stats.length == 1);
-    Assert.assertEquals(1, stats[0]);
     // Ensure only the previous successful one is invoked
+    stats = provider.getProxy().proxy.getStats();
     Mockito.verifyNoMoreInteractions(badMock);
     Mockito.verifyNoMoreInteractions(worseMock);
     Assert.assertEquals(4, counter.get());
@@ -313,15 +311,17 @@ public class TestRequestHedgingProxyProvider {
     Assert.assertTrue(stats.length == 1);
     Assert.assertEquals(2, stats[0]);
 
-    // Counter updates twice since both proxies are tried on failure
-    Assert.assertEquals(7, counter.get());
+    // Counter is updated acording to the number of proxies initially
+    // Created to make sure nothing happens between the exception encoutred
+    // when the invoke method fail with the previous "successfullProxy"
+    Assert.assertEquals(8, counter.get());
 
     stats = provider.getProxy().proxy.getStats();
     Assert.assertTrue(stats.length == 1);
     Assert.assertEquals(2, stats[0]);
 
     // Counter updates only once now
-    Assert.assertEquals(8, counter.get());
+    Assert.assertEquals(9, counter.get());
 
     // Flip to Other standby.. so now this should fail
     isGood[0] = 3;
@@ -333,7 +333,7 @@ public class TestRequestHedgingProxyProvider {
     }
 
     // Counter should ipdate only 1 time
-    Assert.assertEquals(9, counter.get());
+    Assert.assertEquals(10, counter.get());
 
     provider.performFailover(provider.getProxy().proxy);
     stats = provider.getProxy().proxy.getStats();
@@ -343,14 +343,14 @@ public class TestRequestHedgingProxyProvider {
     Assert.assertEquals(3, stats[0]);
 
     // Counter updates twice since both proxies are tried on failure
-    Assert.assertEquals(11, counter.get());
+    Assert.assertEquals(13, counter.get());
 
     stats = provider.getProxy().proxy.getStats();
     Assert.assertTrue(stats.length == 1);
     Assert.assertEquals(3, stats[0]);
 
     // Counter updates only once now
-    Assert.assertEquals(12, counter.get());
+    Assert.assertEquals(14, counter.get());
   }
 
   @Test


### PR DESCRIPTION
Remvove exception trace from info logs in RetryInvocationHandler,
RequestHedgingProxyProvider and Client (during connection exceptions)