### PR TITLE
Add application's live containers endpoint on yarn resourcemanager's Rest API

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/RMAppAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/RMAppAttempt.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 
@@ -40,6 +41,7 @@ import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 import org.apache.hadoop.yarn.security.client.ClientToAMTokenIdentifier;
 import org.apache.hadoop.yarn.server.resourcemanager.blacklist.BlacklistManager;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
+import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
 
 /**
  * Interface to an Application Attempt in the Resource Manager.
@@ -162,6 +164,12 @@ public interface RMAppAttempt extends EventHandler<RMAppAttemptEvent> {
    * @return The AMRMToken belonging to this app attempt
    */
   Token<AMRMTokenIdentifier> getAMRMToken();
+
+  /**
+   * The live containers of this appAttempt
+   * @return The list of live containers
+   */
+  Collection<RMContainer> getLiveContainers();
 
   /**
    * The master key for client-to-AM tokens for this app attempt. This is only

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/RMAppAttemptImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/RMAppAttemptImpl.java
@@ -95,6 +95,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.event.RMAppAt
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.event.RMAppAttemptRegistrationEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.event.RMAppAttemptStatusupdateEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.event.RMAppAttemptUnregistrationEvent;
+import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
 import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerImpl;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeFinishedContainersPulledByAMEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.Allocation;
@@ -647,6 +648,11 @@ public class RMAppAttemptImpl implements RMAppAttempt, Recoverable {
     } finally {
       this.readLock.unlock();
     }
+  }
+
+  @Override
+  public Collection<RMContainer> getLiveContainers(){
+    return this.scheduler.getLiveContainers(applicationAttemptId);
   }
 
   @Private

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -583,4 +583,9 @@ public abstract class AbstractYarnScheduler
   protected void refreshMaximumAllocation(Resource newMaxAlloc) {
     nodeTracker.setConfiguredMaxAllocation(newMaxAlloc);
   }
+
+  @Override
+  public Collection<RMContainer> getLiveContainers(ApplicationAttemptId applicationAttemptId) {
+    return getApplicationAttempt(applicationAttemptId).getLiveContainers();
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/YarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/YarnScheduler.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -281,4 +282,12 @@ public interface YarnScheduler extends EventHandler<SchedulerEvent> {
    * @return SchedulerNode corresponds to nodeId
    */
   SchedulerNode getSchedulerNode(NodeId nodeId);
+
+  /**
+   * Get the current live containers for an ApplicationAttemptId
+   *
+   * @param applicationAttemptId the attemptId
+   * @return A colelction of live RMContainer for this attemptId
+   */
+  Collection<RMContainer> getLiveContainers(ApplicationAttemptId applicationAttemptId);
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/JAXBContextResolver.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/JAXBContextResolver.java
@@ -53,7 +53,9 @@ public class JAXBContextResolver implements ContextResolver<JAXBContext> {
             NodesInfo.class, RemoteExceptionData.class,
             CapacitySchedulerQueueInfoList.class, ResourceInfo.class,
             UsersInfo.class, UserInfo.class, ApplicationStatisticsInfo.class,
-            StatisticsItemInfo.class, FairSchedulerQueueInfoList.class };
+            StatisticsItemInfo.class, FairSchedulerQueueInfoList.class,
+            AttemptContainers.class, AttemptContainers.ContainerInfo.class
+        };
     // these dao classes need root unwrapping
     final Class[] rootUnwrappedTypes =
         { NewApplication.class, ApplicationSubmissionContextInfo.class,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
@@ -84,6 +84,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
+import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.LocalResource;
@@ -104,7 +105,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.RMAuditLogger.AuditConstant
 import org.apache.hadoop.yarn.server.resourcemanager.RMServerUtils;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
+import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttempt;
+import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
+import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerState;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CSQueue;
@@ -135,6 +139,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.SchedulerTypeInf
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.StatisticsItemInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodeLabelsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodeToLabelsInfo;
+import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.AttemptContainers;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.webapp.BadRequestException;
@@ -619,6 +624,53 @@ public class RMWebServices {
   }
 
   @GET
+  @Path("/apps/{appid}/containers/running")
+  @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+  public AttemptContainers getRunningContainers(@Context HttpServletRequest hsr,
+                                                @PathParam("appid") String appId){
+    init();
+    if (appId == null || appId.isEmpty()) {
+      throw new BadRequestException("appId, " + appId + ", is empty or null");
+    }
+    ApplicationId id;
+    id = ConverterUtils.toApplicationId(recordFactory, appId);
+    if (id == null) {
+      throw new NotFoundException("appId is null");
+    }
+    RMApp app = rm.getRMContext().getRMApps().get(id);
+    if (app == null) {
+      throw new NotFoundException("app with id: " + appId + " not found");
+    }
+
+    if(!app.getState().equals(RMAppState.RUNNING)) {
+      throw new BadRequestException("cannot find containers for app not in RUNNING state");
+    }
+
+    RMAppAttempt appAttempt = app.getCurrentAppAttempt();
+    AttemptContainers containers = new AttemptContainers(appAttempt.getAppAttemptId());
+
+    Container am = appAttempt.getMasterContainer();
+    containers.addAm(
+            am.getId().toString(),
+            am.getNodeId().getHost()
+    );
+
+    for(RMContainer rmContainer: app.getCurrentAppAttempt().getLiveContainers()){
+      //we already have the application master so filter it
+      //we also only want allocated and RUNNING containers (and not reserved ones)
+      if(!rmContainer.isAMContainer()
+              && rmContainer.getAllocatedNode() != null
+              && rmContainer.getState().equals(RMContainerState.RUNNING)){
+        containers.add(
+                rmContainer.getContainerId().toString(),
+                rmContainer.getAllocatedNode().getHost()
+        );
+      }
+    }
+    return containers;
+  }
+
+  @GET
   @Path("/apps/{appid}/appattempts")
   @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
   public AppAttemptsInfo getAppAttempts(@PathParam("appid") String appId) {
@@ -789,7 +841,7 @@ public class RMWebServices {
     throws IOException {
     init();
 
-    NodeLabelsInfo ret = 
+    NodeLabelsInfo ret =
       new NodeLabelsInfo(rm.getRMContext().getNodeLabelManager()
         .getClusterNodeLabels());
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
@@ -633,7 +633,11 @@ public class RMWebServices {
       throw new BadRequestException("appId, " + appId + ", is empty or null");
     }
     ApplicationId id;
-    id = ConverterUtils.toApplicationId(recordFactory, appId);
+    try {
+      id = ConverterUtils.toApplicationId(recordFactory, appId);
+    } catch(Exception e){
+      throw new BadRequestException(appId + " is not a valid appId. A valid appId looks like application_1539264296421_0013");
+    }
     if (id == null) {
       throw new NotFoundException("appId is null");
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/AttemptContainers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/AttemptContainers.java
@@ -1,0 +1,63 @@
+package org.apache.hadoop.yarn.server.resourcemanager.webapp.dao;
+
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+
+import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+
+@XmlRootElement(name = "attempt")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class AttemptContainers {
+
+    @XmlAttribute
+    private String id;
+
+    private ContainerInfo am;
+    private ArrayList<ContainerInfo> container = new ArrayList<>();
+
+    public AttemptContainers() {
+    }// JAXB needs this
+
+    public AttemptContainers(ApplicationAttemptId attemptId){
+        this.id = attemptId.toString();
+    }
+
+    public ArrayList<ContainerInfo> getContainer() {
+        return container;
+    }
+
+    public ContainerInfo getAm() {
+        return am;
+    }
+
+    public void add(String containerId, String host) {
+        container.add(new ContainerInfo(containerId, host));
+    }
+
+    public void addAm(String containerId, String host) {
+        am = new ContainerInfo(containerId, host);
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class ContainerInfo {
+
+        private String id;
+        private String host;
+
+        public ContainerInfo() {
+        }// JAXB needs this
+
+        public ContainerInfo(String id, String host) {
+            this.id = id;
+            this.host = host;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getHost() {
+            return host;
+        }
+    }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAttemptContainers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAttemptContainers.java
@@ -1,0 +1,306 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager.webapp;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.servlet.GuiceServletContextListener;
+import com.google.inject.servlet.ServletModule;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.ClientResponse.Status;
+import com.sun.jersey.api.client.UniformInterfaceException;
+import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+import com.sun.jersey.test.framework.JerseyTest;
+import com.sun.jersey.test.framework.WebAppDescriptor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.*;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.resourcemanager.MockAM;
+import org.apache.hadoop.yarn.server.resourcemanager.MockNM;
+import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
+import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
+import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
+import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerState;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fifo.FifoScheduler;
+import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
+import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.ws.rs.core.MediaType;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class TestRMWebServicesAttemptContainers extends JerseyTest {
+
+  private static MockRM rm;
+
+  private static final int CONTAINER_MB = 1024;
+
+  private Injector injector = Guice.createInjector(new ServletModule() {
+    @Override
+    protected void configureServlets() {
+      bind(JAXBContextResolver.class);
+      bind(RMWebServices.class);
+      bind(GenericExceptionHandler.class);
+      Configuration conf = new Configuration();
+      conf.setInt(YarnConfiguration.RM_AM_MAX_ATTEMPTS,
+          YarnConfiguration.DEFAULT_RM_AM_MAX_ATTEMPTS);
+      conf.setClass(YarnConfiguration.RM_SCHEDULER, FifoScheduler.class,
+          ResourceScheduler.class);
+      rm = new MockRM(conf);
+      bind(ResourceManager.class).toInstance(rm);
+      serve("/*").with(GuiceContainer.class);
+    }
+  });
+
+  public class GuiceServletConfig extends GuiceServletContextListener {
+
+    @Override
+    protected Injector getInjector() {
+      return injector;
+    }
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+  }
+
+  public TestRMWebServicesAttemptContainers() {
+    super(new WebAppDescriptor.Builder(
+        "org.apache.hadoop.yarn.server.resourcemanager.webapp")
+        .contextListenerClass(GuiceServletConfig.class)
+        .filterClass(com.google.inject.servlet.GuiceFilter.class)
+        .contextPath("jersey-guice-filter").servletPath("/").build());
+  }
+
+  @Test
+  public void testContainersXML() throws JSONException, Exception {
+    rm.start();
+    MockNM amNodeManager = rm.registerNode("127.0.0.1:1234", 2048 * 100);
+    RMApp app1 = rm.submitApp(CONTAINER_MB, "testwordcount", "user1");
+    MockAM am1 = MockRM.launchAndRegisterAM(app1, rm, amNodeManager);
+    List<Container> containers = am1
+            .allocate("127.0.0.1:1234", 1024, 5, new ArrayList<ContainerId>())
+            .getAllocatedContainers();
+    while (containers.size() != 5) {
+      amNodeManager.nodeHeartbeat(true);
+      containers.addAll(am1.allocate(new ArrayList<ResourceRequest>(),
+              new ArrayList<ContainerId>()).getAllocatedContainers());
+      Thread.sleep(200);
+    }
+
+    //set containers state (remember AM container is id 1)
+    amNodeManager.nodeHeartbeat(am1.getApplicationAttemptId(), 2, ContainerState.RUNNING);
+    amNodeManager.nodeHeartbeat(am1.getApplicationAttemptId(), 3, ContainerState.RUNNING);
+    amNodeManager.nodeHeartbeat(am1.getApplicationAttemptId(), 4, ContainerState.RUNNING);
+    ContainerId containerId2 = ContainerId.newContainerId(am1.getApplicationAttemptId(), 2);
+    ContainerId containerId3 = ContainerId.newContainerId(am1.getApplicationAttemptId(), 3);
+    ContainerId containerId4 = ContainerId.newContainerId(am1.getApplicationAttemptId(), 4);
+    rm.waitForState(amNodeManager, containerId2, RMContainerState.RUNNING);
+    rm.waitForState(amNodeManager, containerId3, RMContainerState.RUNNING);
+    rm.waitForState(amNodeManager, containerId4, RMContainerState.RUNNING);
+
+    WebResource r = resource();
+    ClientResponse response = r.path("ws").path("v1").path("cluster")
+        .path("apps").path(app1.getApplicationId().toString())
+            .path("containers").path("running")
+        .accept(MediaType.APPLICATION_XML)
+        .get(ClientResponse.class);
+    assertEquals(MediaType.APPLICATION_XML_TYPE, response.getType());
+    String xml = response.getEntity(String.class);
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    InputSource is = new InputSource();
+    is.setCharacterStream(new StringReader(xml));
+
+    Document dom = db.parse(is);
+    NodeList nodesAttempt = dom.getElementsByTagName("attempt");
+    assertEquals("incorrect number of elements", 1, nodesAttempt.getLength());
+
+    String attemptId = WebServicesTestUtils.getXmlAttrString((Element) nodesAttempt.item(0), "id");
+    assertEquals(app1.getCurrentAppAttempt().getAppAttemptId().toString(), attemptId);
+
+    NodeList nodeAmList = dom.getElementsByTagName("am");
+    assertEquals("incorrect number of elements", 1, nodeAmList.getLength());
+
+    Element nodeAm = (Element) nodeAmList.item(0);
+
+    Container am = app1.getCurrentAppAttempt().getMasterContainer();
+    verifyContainerXml(am, nodeAm);
+
+    NodeList nodeContainerList = dom.getElementsByTagName("container");
+    //since only 3 containers are running, we expect only 3 results
+    assertEquals("incorrect number of elements", 3, nodeContainerList.getLength());
+
+    //transform nodelist to List and sort for easier testing
+    List<Element> nodeContainerJavaList = transformNodeListToJavaList(nodeContainerList);
+    Collections.sort(nodeContainerJavaList, new Comparator<Element>() {
+      @Override
+      public int compare(Element o1, Element o2) {
+        return WebServicesTestUtils.getXmlString(o1, "id").compareTo(WebServicesTestUtils.getXmlString(o2, "id"));
+      }
+    });
+
+    Element container2El = nodeContainerJavaList.get(0);
+    verifyContainerXml(findContainer(containers, 2), container2El);
+
+    Element container3El = nodeContainerJavaList.get(1);
+    verifyContainerXml(findContainer(containers, 3), container3El);
+
+    Element container4El = nodeContainerJavaList.get(2);
+    verifyContainerXml(findContainer(containers, 4), container4El);
+
+    rm.stop();
+  }
+
+  @Test
+  public void testContainersJSON() throws JSONException, Exception {
+    rm.start();
+    MockNM amNodeManager = rm.registerNode("127.0.0.1:1234", 2048 * 100);
+    RMApp app1 = rm.submitApp(CONTAINER_MB, "testwordcount", "user1");
+    MockAM am1 = MockRM.launchAndRegisterAM(app1, rm, amNodeManager);
+    List<Container> containers = am1
+            .allocate("127.0.0.1:1234", 1024, 5, new ArrayList<ContainerId>())
+            .getAllocatedContainers();
+    while (containers.size() != 5) {
+      amNodeManager.nodeHeartbeat(true);
+      containers.addAll(am1.allocate(new ArrayList<ResourceRequest>(),
+              new ArrayList<ContainerId>()).getAllocatedContainers());
+      Thread.sleep(200);
+    }
+
+    //set containers state (remember AM container is id 1)
+    amNodeManager.nodeHeartbeat(am1.getApplicationAttemptId(), 2, ContainerState.RUNNING);
+    amNodeManager.nodeHeartbeat(am1.getApplicationAttemptId(), 3, ContainerState.RUNNING);
+    amNodeManager.nodeHeartbeat(am1.getApplicationAttemptId(), 4, ContainerState.RUNNING);
+    ContainerId containerId2 = ContainerId.newContainerId(am1.getApplicationAttemptId(), 2);
+    ContainerId containerId3 = ContainerId.newContainerId(am1.getApplicationAttemptId(), 3);
+    ContainerId containerId4 = ContainerId.newContainerId(am1.getApplicationAttemptId(), 4);
+    rm.waitForState(amNodeManager, containerId2, RMContainerState.RUNNING);
+    rm.waitForState(amNodeManager, containerId3, RMContainerState.RUNNING);
+    rm.waitForState(amNodeManager, containerId4, RMContainerState.RUNNING);
+
+    WebResource r = resource();
+    ClientResponse response = r.path("ws").path("v1").path("cluster")
+            .path("apps").path(app1.getApplicationId().toString())
+            .path("containers").path("running")
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
+    assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getType());
+
+    JSONObject json = response.getEntity(JSONObject.class);
+    assertEquals("incorrect number of elements", 1, json.length());
+
+    JSONObject attemptJSON = json.getJSONObject("attempt");
+    assertEquals("incorrect number of elements", 3, attemptJSON.length());
+
+    String attemptId = attemptJSON.getString("id");
+    assertEquals(app1.getCurrentAppAttempt().getAppAttemptId().toString(), attemptId);
+
+    JSONObject amJSON = attemptJSON.getJSONObject("am");
+    assertEquals("incorrect number of elements", 2, amJSON.length());
+
+    Container am = app1.getCurrentAppAttempt().getMasterContainer();
+    verifyContainerJSON(am, amJSON);
+
+    JSONArray containersJSON = attemptJSON.getJSONArray("container");
+    assertEquals("incorrect number of elements", 3, containersJSON.length());
+
+    //transform containersJSON to List and sort for easier testing
+    List<JSONObject> containersList = transformJSONArrayToJavaList(containersJSON);
+    Collections.sort(containersList, new Comparator<JSONObject>() {
+      @Override
+      public int compare(JSONObject o1, JSONObject o2) {
+        try {
+          return o1.getString("id").compareTo(o2.getString("id"));
+        } catch (JSONException e) {
+          return 0;
+        }
+      }
+    });
+
+    JSONObject container2JSON = containersList.get(0);
+    verifyContainerJSON(findContainer(containers, 2), container2JSON);
+
+    JSONObject container3JSON = containersList.get(1);
+    verifyContainerJSON(findContainer(containers, 3), container3JSON);
+
+    JSONObject container4JSON = containersList.get(2);
+    verifyContainerJSON(findContainer(containers, 4), container4JSON);
+
+    rm.stop();
+  }
+
+  private void verifyContainerXml(Container container, Element element) {
+    String id = WebServicesTestUtils.getXmlString(element, "id");
+    assertEquals(container.getId().toString(), id);
+    String host = WebServicesTestUtils.getXmlString(element, "host");
+    assertEquals(container.getNodeId().getHost(), host);
+  }
+
+  private void verifyContainerJSON(Container container, JSONObject object) throws JSONException {
+    String id = object.getString("id");
+    assertEquals(container.getId().toString(), id);
+    String host = object.getString("host");
+    assertEquals(container.getNodeId().getHost(), host);
+  }
+
+  private Container findContainer(List<Container> containers, long id){
+    for(Container c: containers){
+      if(c.getId().getContainerId() == id) {
+        return c;
+      }
+    }
+    throw new IllegalArgumentException("Could not find container " + id + " in provided list");
+  }
+
+  private List<Element> transformNodeListToJavaList(NodeList list){
+    List<Element> nodes = new ArrayList<>();
+    for(int i = 0; i < list.getLength(); i++){
+      nodes.add((Element) list.item(i));
+    }
+    return nodes;
+  }
+
+  private List<JSONObject> transformJSONArrayToJavaList(JSONArray array) throws JSONException {
+    List<JSONObject> objects = new ArrayList<>();
+    for(int i = 0; i < array.length(); i++){
+      objects.add((JSONObject) array.get(i));
+    }
+    return objects;
+  }
+
+}
+


### PR DESCRIPTION
Endpoint will return an error if app is not in running state

Otherwise it will return containerId and host for all allocated and running containers of an application at the moment the service is called.

Example of response for a running app
JSON
{  
   "attempt":{  
      "id":"appattempt_1539264296421_0013_000002",
      "am":{  
         "id":"container_e1110_1539264296421_0013_02_000001",
         "host":"a4-5d-36-fd-81-48.hpc.criteo.preprod"
      },
      "container":[  
         {  
            "id":"container_e1110_1539264296421_0013_02_000038",
            "host":"a4-5d-36-fd-71-c0.hpc.criteo.preprod"
         },
         {  
            "id":"container_e1110_1539264296421_0013_02_000005",
            "host":"a4-5d-36-fd-22-e4.hpc.criteo.preprod"
         }
      ]
   }
}


XML
<?xml version="1.0" encoding="UTF-8"?>
<attempt id="appattempt_1539264296421_0013_000002">
   <am>
      <id>container_e1110_1539264296421_0013_02_000001</id>
      <host>a4-5d-36-fd-81-48.hpc.criteo.preprod</host>
   </am>
   <container>
      <id>container_e1110_1539264296421_0013_02_000038</id>
      <host>a4-5d-36-fd-71-c0.hpc.criteo.preprod</host>
   </container>
   <container>
      <id>container_e1110_1539264296421_0013_02_000005</id>
      <host>a4-5d-36-fd-22-e4.hpc.criteo.preprod</host>
   </container>
   <container>
      <id>container_e1110_1539264296421_0013_02_000042</id>
      <host>68-8f-84-f2-74-92.hpc.criteo.preprod</host>
   </container>
</attempt>

Example of response for non running app

JSON
status 404 if app does not exists
status 400 if appid is not provided in the request or if app is not in RUNNING state
{  
   "RemoteException":{  
      "exception":"NotFoundException",
      "message":"java.lang.Exception: cannot find containers for non running app",
      "javaClassName":"org.apache.hadoop.yarn.webapp.NotFoundException"
   }
}

XML
Yarn returns a server error status 500 on all endpoints without exception detail