### PR TITLE
Add LIBHDFS_CLASSPATH so we could define specific classpath for libhdfs

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/native/libhdfs/jni_helper.c
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/native/libhdfs/jni_helper.c
@@ -393,11 +393,14 @@ static JNIEnv* getGlobalJNIEnv(void)
 
     if (noVMs == 0) {
         //Get the environment variables for initializing the JVM
-        hadoopClassPath = getenv("CLASSPATH");
+        hadoopClassPath = getenv("LIBHDFS_CLASSPATH");
         if (hadoopClassPath == NULL) {
-            fprintf(stderr, "Environment variable CLASSPATH not set!\n");
-            return NULL;
-        } 
+            hadoopClassPath = getenv("CLASSPATH");
+            if (hadoopClassPath == NULL) {
+                fprintf(stderr, "Environment variables LIBHDFS_CLASSPATH or CLASSPATH not set!\n");
+                return NULL;
+            }
+        }
         optHadoopClassPathLen = strlen(hadoopClassPath) + 
           strlen(hadoopClassPathVMArg) + 1;
         optHadoopClassPath = malloc(sizeof(char)*optHadoopClassPathLen);


### PR DESCRIPTION
This will avoid impacting all containers exposing a non glob classpath
for libhdfs on another env variables than CLASSPATH