### PR TITLE
Added a configuration for admins to be able to capped per-container cpu usage based on a multiplier

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1146,7 +1146,15 @@ public class YarnConfiguration extends Configuration {
   public static final boolean DEFAULT_NM_LINUX_CONTAINER_CGROUPS_STRICT_RESOURCE_USAGE =
       false;
 
-
+  /**
+   * In case of strict resource usage provide capability to capped cpu resource
+   * usage by <code>DEFAULT_NM_LINUX_CONTAINER_CGROUPS_CAPPED_MULTIPLIER</code>
+   * times the requested one
+   */
+  public static final String NM_LINUX_CONTAINER_CGROUPS_CAPPED_MULTIPLIER =
+          NM_PREFIX + "linux-container-executor.cgroups.capped-multiplier";
+  public static final float DEFAULT_NM_LINUX_CONTAINER_CGROUPS_CAPPED_MULTIPLIER =
+          1.0f;
 
   /**
    * Interval of time the linux container executor should try cleaning up

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1139,9 +1139,27 @@
   </property>
 
   <property>
+    <description>If yarn.nodemanager.linux-container-executor.cgroups.strict-resource-usage
+      is set to true this flag determines how many times their share of CPU they can use. For
+      example setting it to 1.0f will restrict apps to use only their share of CPU but setting it to 2.0f
+      will authorize apps to use up to 2 times their share of CPU.
+    </description>
+    <name>yarn.nodemanager.linux-container-executor.cgroups.capped-multiplier</name>
+    <value>1.0f</value>
+  </property>
+
+  <property>
     <description>T-file compression types used to compress aggregated logs.</description>
     <name>yarn.nodemanager.log-aggregation.compression-type</name>
     <value>none</value>
+  </property>
+
+  <property>
+    <description>Comma separated list of runtimes that are allowed when using
+    LinuxContainerExecutor. The allowed values are default, docker, and
+    javasandbox.</description>
+    <name>yarn.nodemanager.runtime.linux.allowed-runtimes</name>
+    <value>default</value>
   </property>
 
   <property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/util/TestCgroupsLCEResourcesHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/util/TestCgroupsLCEResourcesHandler.java
@@ -324,8 +324,29 @@ public class TestCgroupsLCEResourcesHandler {
     Assert.assertEquals(500 * 1000, readIntFromFile(periodFile));
     Assert.assertEquals(1000 * 1000, readIntFromFile(quotaFile));
 
+    // 1/8 of CPU with multiplier set at 2
+    FileUtils.deleteQuietly(containerCpuDir);
+    conf.setBoolean(
+            YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_STRICT_RESOURCE_USAGE,
+        true);
+    conf.setFloat(
+            YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_CAPPED_MULTIPLIER,
+            2.0f);
+    handler.initConfig();
+    handler.preExecute(id,
+            Resource.newInstance(1024, YarnConfiguration.DEFAULT_NM_VCORES / 8));
+    Assert.assertTrue(containerCpuDir.exists());
+    Assert.assertTrue(containerCpuDir.isDirectory());
+    periodFile = new File(containerCpuDir, "cpu.cfs_period_us");
+    quotaFile = new File(containerCpuDir, "cpu.cfs_quota_us");
+    Assert.assertTrue(periodFile.exists());
+    Assert.assertTrue(quotaFile.exists());
+    Assert.assertEquals(1000 * 1000, readIntFromFile(periodFile));
+    Assert.assertEquals(1000 * 1000, readIntFromFile(quotaFile));
+
     // CGroups set to 50% of CPU, container set to 50% of YARN CPU
     FileUtils.deleteQuietly(containerCpuDir);
+    conf.unset(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_CAPPED_MULTIPLIER);
     conf.setBoolean(
         YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_STRICT_RESOURCE_USAGE,
         true);


### PR DESCRIPTION
Let me know if you agreed with this patch and with adding this kind of capping on our cluster.
If it is the case I will create a request on the open source side and also push this patcch on top of our HDP 3 branch