### PR TITLE
Revert "[HDP-8477] Remove exception trace from info logs"

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryInvocationHandler.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryInvocationHandler.java
@@ -228,7 +228,7 @@ public class RetryInvocationHandler<T> implements RpcInvocationHandler {
       if (retryInfo.action.reason != null) {
         LOG.warn("Exception while invoking "
             + proxyDescriptor.getProxyInfo().getString(method.getName())
-            + ". Not retrying because " + retryInfo.action.reason);
+            + ". Not retrying because " + retryInfo.action.reason, ex);
       }
       throw retryInfo.getFailException();
     }
@@ -256,23 +256,27 @@ public class RetryInvocationHandler<T> implements RpcInvocationHandler {
   }
 
   private void log(final Method method, final boolean isFailover,
-                   final int failovers, final long delay, final Exception ex) {
+      final int failovers, final long delay, final Exception ex) {
     // log info if this has made some successful calls or
     // this is not the first failover
-    final StringBuilder b =
-        new StringBuilder()
-            .append("Exception while invoking ")
-            .append(proxyDescriptor.getProxyInfo().getString(method.getName()));
+    final boolean info = hasMadeASuccessfulCall || failovers != 0;
+    if (!info && !LOG.isDebugEnabled()) {
+      return;
+    }
+
+    final StringBuilder b = new StringBuilder()
+        .append("Exception while invoking ")
+        .append(proxyDescriptor.getProxyInfo().getString(method.getName()));
     if (failovers > 0) {
       b.append(" after ").append(failovers).append(" failover attempts");
     }
-    b.append(isFailover ? ". Trying to failover " : ". Retrying ")
-        .append(delay > 0 ? "after sleeping for " + delay + "ms." : "immediately.");
+    b.append(isFailover? ". Trying to failover ": ". Retrying ");
+    b.append(delay > 0? "after sleeping for " + delay + "ms.": "immediately.");
 
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(b.append(" Reason: ").toString(), ex);
+    if (info) {
+      LOG.info(b.toString(), ex);
     } else {
-      LOG.warn(b.toString());
+      LOG.debug(b.toString(), ex);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -854,7 +854,7 @@ public class Client {
       if (action.action == RetryAction.RetryDecision.FAIL) {
         if (action.reason != null) {
           LOG.warn("Failed to connect to server: " + server + ": "
-              + action.reason);
+              + action.reason, ioe);
         }
         throw ioe;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/RequestHedgingProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/RequestHedgingProxyProvider.java
@@ -234,6 +234,8 @@ public class RequestHedgingProxyProvider<T> extends
         LOG.debug("Invocation returned standby exception on [" +
             proxyInfo + "]");
       }
+    } else {
+      LOG.warn("Invocation returned exception on [" + proxyInfo + "]");
     }
   }
 


### PR DESCRIPTION
The modification of the log level while not using
RequestHedgingProxyProvider do generate a warn log each time there is a
failover or the first namenode tested is standby

This reverts commit e5e74e6d50994f6c22b82e9cbe001bfe86fa52bb.