### PR TITLE
Manage NullPointerException on HadoopArchiveLogs job

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
@@ -304,7 +304,8 @@ public class HadoopArchiveLogs implements Tool {
           ApplicationReport report = client.getApplicationReport(
               ConverterUtils.toApplicationId(app.getAppId()));
           LogAggregationStatus aggStatus = report.getLogAggregationStatus();
-          if (aggStatus.equals(LogAggregationStatus.RUNNING) ||
+          if (aggStatus == null ||
+              aggStatus.equals(LogAggregationStatus.RUNNING) ||
               aggStatus.equals(LogAggregationStatus.RUNNING_WITH_FAILURE) ||
               aggStatus.equals(LogAggregationStatus.NOT_START) ||
               aggStatus.equals(LogAggregationStatus.DISABLED) ||


### PR DESCRIPTION
One Flink job which was finished successfully was not containing
a LogAggregationStatus. Which leads to the HadoopArchiveLogs job
failing with NullPointerException
Not taking in account those jobs if they are no LogAggregationStatus
will be sufficient