### PR TITLE
Increase yarn tags limits

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -64,10 +64,10 @@ public class YarnConfiguration extends Configuration {
           CORE_SITE_CONFIGURATION_FILE));
 
   @Evolving
-  public static final int APPLICATION_MAX_TAGS = 10;
+  public static final int APPLICATION_MAX_TAGS = 15;
 
   @Evolving
-  public static final int APPLICATION_MAX_TAG_LENGTH = 100;
+  public static final int APPLICATION_MAX_TAG_LENGTH = 200;
 
   static {
     addDeprecatedKeys();


### PR DESCRIPTION
max number of tags to 15
max size to 200 chars