### PR TITLE
Add admin-env-override parameter to be able to set/replace container env variables and add container hadoop release detection to load specific config depending to hadoop client release

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1117,6 +1117,10 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_ADMIN_USER_ENV = NM_PREFIX + "admin-env";
   public static final String DEFAULT_NM_ADMIN_USER_ENV = "MALLOC_ARENA_MAX=$MALLOC_ARENA_MAX";
 
+  /** Environment variables that will be overriden on containers.*/
+  public static final String NM_ADMIN_USER_ENV_OVERRIDE = NM_PREFIX + "admin-env-override";
+  public static final String DEFAULT_NM_ADMIN_USER_ENV_OVERRIDE = "";
+
   /** Environment variables that containers may override rather than use NodeManager's default.*/
   public static final String NM_ENV_WHITELIST = NM_PREFIX + "env-whitelist";
   public static final String DEFAULT_NM_ENV_WHITELIST = StringUtils.join(",",

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1117,9 +1117,21 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_ADMIN_USER_ENV = NM_PREFIX + "admin-env";
   public static final String DEFAULT_NM_ADMIN_USER_ENV = "MALLOC_ARENA_MAX=$MALLOC_ARENA_MAX";
 
+  /** Environment variables that will be sent to containers.*/
+  public static final String NM_HADOOP2_CONF_DIR = NM_PREFIX + "hadoop2-conf-dir";
+  public static final String DEFAULT_NM_HADOOP2_CONF_DIR = "/etc/hadoop2/conf";
+
+  /** Environment variables that will be sent to containers.*/
+  public static final String NM_ADMIN_USER_ENV_HADOOP2 = NM_PREFIX + "admin-env-hadoop2";
+  public static final String DEFAULT_NM_ADMIN_USER_ENV_HADOOP2 = "MALLOC_ARENA_MAX=$MALLOC_ARENA_MAX";
+
   /** Environment variables that will be overriden on containers.*/
   public static final String NM_ADMIN_USER_ENV_OVERRIDE = NM_PREFIX + "admin-env-override";
   public static final String DEFAULT_NM_ADMIN_USER_ENV_OVERRIDE = "";
+
+  /** Environment variables that will be overriden on containers.*/
+  public static final String NM_ADMIN_USER_ENV_OVERRIDE_HADOOP2 = NM_PREFIX + "admin-env-override-hadoop2";
+  public static final String DEFAULT_NM_ADMIN_USER_ENV_OVERRIDE_HADOOP2 = "";
 
   /** Environment variables that containers may override rather than use NodeManager's default.*/
   public static final String NM_ENV_WHITELIST = NM_PREFIX + "env-whitelist";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/containerlaunch/ClasspathConstructor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/containerlaunch/ClasspathConstructor.java
@@ -45,7 +45,6 @@ public class ClasspathConstructor {
 
 
   /**
-   * Get the list of JARs from the YARN settings
    * @param config configuration
    */
   public List<String> yarnApplicationClasspath(Configuration config) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Apps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Apps.java
@@ -107,6 +107,26 @@ public class Apps {
     }
   }
 
+  public static void overrideEnvFromInputString(Map<String, String> env,
+                                           String envString) {
+    if (envString != null && envString.length() > 0) {
+      Matcher varValMatcher = VARVAL_SPLITTER.matcher(envString);
+      while (varValMatcher.find()) {
+        String envVar = varValMatcher.group(1);
+
+        Matcher m = VAR_SUBBER.matcher(varValMatcher.group(2));
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+          String var = m.group(1);
+          String replace = System.getenv(var);
+          m.appendReplacement(sb, Matcher.quoteReplacement(replace));
+        }
+        m.appendTail(sb);
+        env.put(envVar, sb.toString());
+      }
+    }
+  }
+
   /**
    *
    * @param envString String containing env variable definitions

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1058,6 +1058,13 @@
   </property>
 
   <property>
+    <description>Environment variables that should be forwarded from the NodeManager's environment to the container's.
+      They will override the containers one if exist.</description>
+    <name>yarn.nodemanager.admin-env-override</name>
+    <value></value>
+  </property>
+
+  <property>
     <description>Environment variables that containers may override rather than use NodeManager's default.</description>
     <name>yarn.nodemanager.env-whitelist</name>
     <value>JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,CLASSPATH_PREPEND_DISTCACHE,HADOOP_YARN_HOME,HADOOP_HOME,PATH,LANG,TZ</value>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestApps.java
@@ -58,4 +58,18 @@ public class TestApps {
     assertEquals("=", environment.get("e1"));
     assertEquals("a1=a2", environment.get("e2"));
   }
+
+  @Test
+  public void testOverrideEnvFromInputString() {
+    Map<String, String> environment = new HashMap<String, String>();
+    environment.put("JAVA_HOME", "/path/jdk");
+    String goodEnv = "a1=1,b_2=2,_c=3,d=4,e=,JAVA_HOME=/test";
+    Apps.overrideEnvFromInputString(environment, goodEnv);
+    assertEquals("1", environment.get("a1"));
+    assertEquals("2", environment.get("b_2"));
+    assertEquals("3", environment.get("_c"));
+    assertEquals("4", environment.get("d"));
+    assertEquals("", environment.get("e"));
+    assertEquals("/test", environment.get("JAVA_HOME"));
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestApps.java
@@ -72,4 +72,13 @@ public class TestApps {
     assertEquals("", environment.get("e"));
     assertEquals("/test", environment.get("JAVA_HOME"));
   }
+
+  @Test
+  public void testHadoopRelease() {
+    Map<String, String> environment = new HashMap<String, String>();
+    environment.put("YARN_HADOOP_RELEASE", "2");
+    assertEquals(2, Apps.getHadoopRelease(environment));
+    environment = new HashMap<String, String>();
+    assertEquals(3, Apps.getHadoopRelease(environment));
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -1720,6 +1720,14 @@ public class ContainerLaunch implements Callable<Integer> {
     nmVars.addAll(Apps.getEnvVarsFromInputString(nmAdminUserEnv,
         File.pathSeparator));
 
+    // variables here will be override in.
+    String nmAdminUserEnvOverride = conf.get(
+        YarnConfiguration.NM_ADMIN_USER_ENV_OVERRIDE,
+        YarnConfiguration.DEFAULT_NM_ADMIN_USER_ENV_OVERRIDE);
+    Apps.overrideEnvFromInputString(environment, nmAdminUserEnvOverride);
+    nmVars.addAll(Apps.getEnvVarsFromInputString(nmAdminUserEnvOverride,
+        File.pathSeparator));
+
     // TODO: Remove Windows check and use this approach on all platforms after
     // additional testing.  See YARN-358.
     if (Shell.WINDOWS) {


### PR DESCRIPTION
admin-env provide ability to forward nodemanagers environment variable to the containers
but it leads to env vraiable beeing merged if it already exists on the containers with class file separator
so we finally have CRITEO_DC=am6:am6 instead of am6
this new parameter will just override the container var ones

Let me know if you want this patch to be backported on cdh5 (no real needs as NM forward env variables to containers without adding it to admin-env)

Also add container hadoop release detection to load specific config depending to hadoop client release:
One of our use case is to launch some jobs from an AppMaster. This leads to classpath issue on client jobs
as they are launched using compute nodes config which points to hadoop 3 classes.