### PR TITLE
Add hadoop 2 conf dir at the beginning of the container classpath

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/containerlaunch/ClasspathConstructor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/containerlaunch/ClasspathConstructor.java
@@ -45,6 +45,7 @@ public class ClasspathConstructor {
 
 
   /**
+   * Get the list of JARs from the YARN settings
    * @param config configuration
    */
   public List<String> yarnApplicationClasspath(Configuration config) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -1738,6 +1738,16 @@ public class ContainerLaunch implements Callable<Integer> {
       nmAdminUserEnvOverride = conf.get(
         YarnConfiguration.NM_ADMIN_USER_ENV_OVERRIDE_HADOOP2,
         YarnConfiguration.DEFAULT_NM_ADMIN_USER_ENV_OVERRIDE_HADOOP2);
+
+      // Put hadoop 2 conf at the beginning of the classpath
+      String inputClassPath = environment.get(Environment.CLASSPATH.name());
+      if (inputClassPath != null && !inputClassPath.isEmpty()) {
+        String newClassPath = conf.get(
+            YarnConfiguration.NM_HADOOP2_CONF_DIR,
+            YarnConfiguration.DEFAULT_NM_HADOOP2_CONF_DIR) + File.pathSeparator +
+            inputClassPath;
+        environment.put(Environment.CLASSPATH.name(), newClassPath);
+      }
     }
 
     // variables here will be forced in, even if the container has specified them.


### PR DESCRIPTION
Change b4001822f2151efbb5327d3d19b5c721510537f8 provide a way to detect haoop2 and
change the HADOOP_CONF_DIR env variable to point to hadoop 2 config folders
New jobs launche through a bash command are well loading the conf from hadoop 2 conf folder
but if jobs are launched directly from the AppMaster JVM it will base its confirguration from the
conf folder already set on the classpath which points to the hadoop 3 one
This commits will enforce loading config from hadoop 2 conf dir

Also ClasspathConstructor.java was badly update so reverting this part