### PR TITLE
Fix hadoop-hdfs test that where using MiniDFSCluster

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
@@ -783,7 +783,9 @@ public class MiniDFSCluster {
       this.checkExitOnShutdown = checkExitOnShutdown;
     
       int replication = conf.getInt(DFS_REPLICATION_KEY, 3);
-      conf.setInt(DFS_REPLICATION_KEY, Math.min(replication, numDataNodes));
+      int minRplication = Math.min(replication, numDataNodes);
+      conf.setInt(DFS_REPLICATION_KEY, minRplication);
+      conf.setInt(DFSConfigKeys.DFS_NAMENODE_SAFEMODE_REPLICATION_MIN_KEY, minRplication);
       int maintenanceMinReplication = conf.getInt(
           DFSConfigKeys.DFS_NAMENODE_MAINTENANCE_REPLICATION_MIN_KEY,
           DFSConfigKeys.DFS_NAMENODE_MAINTENANCE_REPLICATION_MIN_DEFAULT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
@@ -785,7 +785,9 @@ public class MiniDFSCluster {
       int replication = conf.getInt(DFS_REPLICATION_KEY, 3);
       int minRplication = Math.min(replication, numDataNodes);
       conf.setInt(DFS_REPLICATION_KEY, minRplication);
-      conf.setInt(DFSConfigKeys.DFS_NAMENODE_SAFEMODE_REPLICATION_MIN_KEY, minRplication);
+      int replicationNNMin = conf.getInt(DFSConfigKeys.DFS_NAMENODE_REPLICATION_MIN_KEY, minRplication);
+      int minReplicationNNMin = Math.min(replicationNNMin, minRplication);
+      conf.setInt(DFSConfigKeys.DFS_NAMENODE_SAFEMODE_REPLICATION_MIN_KEY, minReplicationNNMin);
       int maintenanceMinReplication = conf.getInt(
           DFSConfigKeys.DFS_NAMENODE_MAINTENANCE_REPLICATION_MIN_KEY,
           DFSConfigKeys.DFS_NAMENODE_MAINTENANCE_REPLICATION_MIN_DEFAULT);


### PR DESCRIPTION
In commit 4bc5d71c97e - [HDFS-13295] - Namenode doesn't leave safemode if dfs.namenode.safemode.replication.min set (#78)
we compare this DFS_NAMENODE_SAFEMODE_REPLICATION_MIN_KEY with defaultReplication, which is equal to zero most of the time in
miniHDFSCluster, so most test were throwing an exception because minSafemodeR is > than defaultReplication.

Now we set also in miniDFScluster DFS_NAMENODE_SAFEMODE_REPLICATION_MIN_KEY to replicationFactor.