### PR TITLE
POC - ! DO NOT MERGE ! Launch containers in a specific network namespace

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/LinuxContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/LinuxContainerExecutor.java
@@ -673,6 +673,12 @@ public class LinuxContainerExecutor extends ContainerExecutor {
       .setExecutionAttribute(CONTAINER_LOG_DIRS, ctx.getContainerLogDirs())
       .setExecutionAttribute(RESOURCES_OPTIONS, resourcesOptions);
 
+    if(ctx.getContainer().getLaunchContext().getEnvironment().containsKey("NETNS_NAME")) {
+      String netnsName = ctx.getContainer().getLaunchContext().getEnvironment().get("NETNS_NAME");
+      ctx.getContainer().getLaunchContext().getEnvironment().remove("NETNS_NAME");
+      builder.setExecutionAttribute(NETNS_NAME, netnsName);
+    }
+
     if (tcCommandFile != null) {
       builder.setExecutionAttribute(TC_COMMAND_FILE, tcCommandFile);
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/DefaultLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/DefaultLinuxContainerRuntime.java
@@ -102,6 +102,11 @@ public class DefaultLinuxContainerRuntime implements LinuxContainerRuntime {
             ctx.getExecutionAttribute(LOG_DIRS)),
         ctx.getExecutionAttribute(RESOURCES_OPTIONS));
 
+    String netnsName = ctx.getExecutionAttribute(NETNS_NAME);
+    if(netnsName != null) {
+      launchOp.appendArgs(netnsName);
+    }
+
     String tcCommandFile = ctx.getExecutionAttribute(TC_COMMAND_FILE);
 
     if (tcCommandFile != null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/LinuxContainerRuntimeConstants.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/LinuxContainerRuntimeConstants.java
@@ -78,6 +78,8 @@ public final class LinuxContainerRuntimeConstants {
       List.class, "container_log_dirs");
   public static final Attribute<String> RESOURCES_OPTIONS = Attribute.attribute(
       String.class, "resources_options");
+  public static final Attribute<String> NETNS_NAME = Attribute.attribute(
+          String.class, "netns_name");
   public static final Attribute<String> TC_COMMAND_FILE = Attribute.attribute(
       String.class, "tc_command_file");
   public static final Attribute<List> CONTAINER_RUN_CMDS = Attribute.attribute(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
@@ -46,6 +46,7 @@
 #include <sys/mount.h>
 #include <sys/wait.h>
 #include <getopt.h>
+#include <sched.h>
 
 #ifndef HAVE_FCHMODAT
 #include "compat/fchmodat.h"
@@ -904,6 +905,27 @@ struct passwd* check_user(const char *user) {
     free_values(banned_users);
   }
   return user_info;
+}
+
+/**
+ * Set the net namespace
+ */
+int set_ns(const char *netns_name) {
+
+    char fd_path[256] = "/var/run/netns/";
+    strcat(fd_path, netns_name);
+    int fd = open(fd_path, O_RDONLY);
+    if (fd == -1) {
+        fprintf(LOGFILE, "Tried to set an unknown namespace %s\n",
+        netns_name);
+        return -1;
+    }
+    if(setns(fd, CLONE_NEWNET) != 0) {
+        fprintf(LOGFILE, "Error setting netns %s for container: %s\n",
+        netns_name, strerror(errno));
+        return -1;
+    };
+
 }
 
 /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.h
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.h
@@ -175,6 +175,9 @@ struct passwd* check_user(const char *user);
 // set the user
 int set_user(const char *user);
 
+// set the net namespace
+int set_ns(const char *netns_name);
+
 // methods to get the directories
 
 char *get_user_directory(const char *nm_root, const char *user);


### PR DESCRIPTION
This commit illustrate the changes to be made to launch container in a specific network ns.

The network has to be already created on the yarn nodes.

This change shows how this can be implemented via Environnement. Another approach would be to base decision on user name.