### PR TITLE
Use hostname canonicalization consistently for Kerberos

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/client/KerberosAuthenticator.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/client/KerberosAuthenticator.java
@@ -16,6 +16,7 @@ package org.apache.hadoop.security.authentication.client;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.security.authentication.util.AuthToken;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
+import org.apache.http.client.utils.URIBuilder;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
@@ -31,6 +32,8 @@ import javax.security.auth.login.LoginException;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.AccessControlContext;
 import java.security.AccessController;
@@ -178,9 +181,16 @@ public class KerberosAuthenticator implements Authenticator {
   public void authenticate(URL url, AuthenticatedURL.Token token)
     throws IOException, AuthenticationException {
     if (!token.isSet()) {
-      this.url = url;
+      try {
+        URIBuilder uriBuilder = new URIBuilder(url.toURI());
+        uriBuilder.setHost(InetAddress.getByName(url.getHost()).getCanonicalHostName());
+        this.url = uriBuilder.build().toURL();
+      } catch (URISyntaxException exception) {
+        throw new AuthenticationException("cannot convert url " + url + " to uri for spnego hostname canonicalization");
+      }
+
       base64 = new Base64(0);
-      conn = (HttpURLConnection) url.openConnection();
+      conn = (HttpURLConnection) this.url.openConnection();
       if (connConfigurator != null) {
         conn = connConfigurator.configure(conn);
       }
@@ -209,7 +219,7 @@ public class KerberosAuthenticator implements Authenticator {
         // Otherwise the fall back authenticator might not have the information
         // to make the connection (e.g., SSL certificates)
         auth.setConnectionConfigurator(connConfigurator);
-        auth.authenticate(url, token);
+        auth.authenticate(this.url, token);
       }
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SecurityUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SecurityUtil.java
@@ -165,7 +165,7 @@ public class SecurityUtil {
         || !components[1].equals(HOSTNAME_PATTERN)) {
       return principalConfig;
     } else {
-      return replacePattern(components, hostname);
+      return replacePattern(components, InetAddress.getByName(hostname).getCanonicalHostName());
     }
   }
   


### PR DESCRIPTION
Canonicalization is essential to kerberos when the hostname used to reach a service is different than the fqdn present in the principal.

  - in SecurityUtils, most computation paths involving the method getServerPrincipal will use the canonicalized hostame, but the one were the caller of the method directly sets a hostname (and even this method, in case the hostname given is 0.0.0.0 would use the canonicalized localhost) -> this fix correct this behavior inconsistency by systematically using the canonicalized hostname.
  - in KerberosAuthneticator, the SPNEGO is made using the hostname in the URI. The underlying java stack managing kerberos uses this hostname to create the SPNEGO ticket, but in the case the hostname does not match the principal of the server, it would have been necessary to use the canonicalized hostname -> this fix forges a new URL based on the canonicalized hostname