### PR TITLE
Fix HeartbeatResponse between Namenode HDP 3 and datanodes HDP 2

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/DatanodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/DatanodeProtocol.proto
@@ -222,6 +222,14 @@ message HeartbeatResponseProto {
   optional RollingUpgradeStatusProto rollingUpgradeStatusV2 = 5;
 }
 
+message HeartbeatResponseHDP3Proto {
+  repeated DatanodeCommandProto cmds = 1; // Returned commands can be null
+  required NNHAStatusHeartbeatProto haStatus = 2;
+  optional RollingUpgradeStatusProto rollingUpgradeStatus = 3;
+  optional RollingUpgradeStatusProto rollingUpgradeStatusV2 = 4;
+  optional uint64 fullBlockReportLeaseId = 5 [ default = 0 ];
+}
+
 /**
  * registration - datanode registration information
  * blockPoolID  - block pool ID of the reported blocks


### PR DESCRIPTION
HeartbeatResponseProto messages have different layouts between HDP3 and HDP2, they use the same fields but some indexes are switched. That leads HDP2 datanode to incorrectly parse the fullBlockReportLeaseId, and as a consequence, datanodes cannot perform full block reports.

The workaround relies on the fact that protobuf is able to detect the presence of unknown fields in a message. Thus when a datanode HDP 2 receives a HeartbeatResponse from a Namenode HDP 3, we can detect the presence of such unknown field. In this case, we can reserialize the message with the correct protobuf message and access all expected fields.

This mechanism is implemented through a wrapper class, as protobuf messages uses final class, polymorphism was not an option.