### PR TITLE
Fix BlockTokenIdentifier password computation between Namenode HDP3 and datanodes HDP2

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/block/BlockTokenIdentifier.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/block/BlockTokenIdentifier.java
@@ -160,6 +160,7 @@ public class BlockTokenIdentifier extends TokenIdentifier {
       modes.add(WritableUtils.readEnum(in, AccessMode.class));
     }
 
+    //the following lines comes from the same class on branch-3.3.0
     try {
       length = WritableUtils.readVInt(in);
       StorageType[] readStorageTypes = new StorageType[length];
@@ -199,6 +200,8 @@ public class BlockTokenIdentifier extends TokenIdentifier {
     for (AccessMode aMode : modes) {
       WritableUtils.writeEnum(out, aMode);
     }
+
+    //the following lines comes from the same class on branch-3.3.0
     if (storageTypes != null) {
       WritableUtils.writeVInt(out, storageTypes.length);
       for (StorageType type : storageTypes) {


### PR DESCRIPTION
When a datanode registers the the namenode, the namenode transmits a set of keys, that consists in an id and a random long value. Those keys are used as seed to a cryptographic function to compute hashes.

When the namenode generates a BlockTokenIdentifier it does the following:
  - serialize it with its write method
  - get one of the keys
  - compute a hash with this key as seed
  - send the BlockTokenIdentifier as binary stream to the datanode, along with the key id used and the expected hash

The datanode receiving the BlockTokenIdentifier does the following:
  - deserialize the BlockTokenIdentifer
  - get the key id
  - reserialize the BlockTokenIdentifier
  - compute the hash with its own copy of the key (in memory)
  - verify the computed hash against the exepected one

With HDP3, the namenode sends additional data in the byte array. The HDP2 datanode ignores this data, so when it reserializes the BlockTokenIdentifier, the byte array does not correspond to the one the namenode used to compute the hash. Thus, even if the datanode has the correct keys, it is not able to get the same hash.

The fix consists in deserializing/serializing this additional data, if it exists. Hashes are then correctly computed, whether the namenode is HDP3 or HDP2.