### PR TITLE
Add some metrics for read locality

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopology.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopology.java
@@ -920,7 +920,7 @@ public class NetworkTopology {
    * @param node Replica of data
    * @return weight
    */
-  protected int getWeight(Node reader, Node node) {
+  public int getWeight(Node reader, Node node) {
     // 0 is local, 1 is same rack, 2 is off rack
     // Start off by initializing to off rack
     int weight = 2;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopologyWithNodeGroup.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopologyWithNodeGroup.java
@@ -254,7 +254,7 @@ public class NetworkTopologyWithNodeGroup extends NetworkTopology {
   }
 
   @Override
-  protected int getWeight(Node reader, Node node) {
+  public int getWeight(Node reader, Node node) {
     // 0 is local, 1 is same node group, 2 is same rack, 3 is off rack
     // Start off by initializing to off rack
     int weight = 3;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1986,7 +1986,14 @@ public class FSNamesystem implements Namesystem, FSClusterStats,
         measureDistanceToFirstLocation(clientMachine, b);
       }
       // lastBlock is not part of getLocatedBlocks(), so we need to check it individually
-      if (lastBlock != null) {
+      // That's a comment above, but through testing, sometime,
+      // lastLocatedBlock is the same block as the last located block in the list
+      // thus add one test to check equality between lastBlock and the last in LocatedBlocks list
+      int locatedBlocksSize = blocks.getLocatedBlocks().size();
+      if (lastBlock != null &&
+              locatedBlocksSize > 0 &&
+              !lastBlock.getBlock().equals(blocks.getLocatedBlocks().get(locatedBlocksSize - 1).getBlock())
+      ) {
         measureDistanceToFirstLocation(clientMachine, lastBlock);
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2004,7 +2004,7 @@ public class FSNamesystem implements Namesystem, FSClusterStats,
   private void measureDistanceToFirstLocation(String clientMachine, LocatedBlock locatedBlock) {
     DatanodeInfo[] locs = locatedBlock.getLocations();
     if(locs.length > 0) {
-      DatanodeInfo closerLocation = locs[0];
+      DatanodeInfo closestLocation = locs[0];
       NetworkTopology networkTopology = blockManager.getDatanodeManager().getNetworkTopology();
 
       //mimic code in DatanodeManager.sortLocatedBlocks
@@ -2028,7 +2028,7 @@ public class FSNamesystem implements Namesystem, FSClusterStats,
       }
 
       //client could be null due to the code above, but getWeight method accepts null first parameter
-      int weight = networkTopology.getWeight(client, closerLocation);
+      int weight = networkTopology.getWeight(client, closestLocation);
       //describe in method getWeight: 0 is local, 1 is same rack, 2 is off rack
       ReadLocalityMetrics readLocalityMetrics = NameNode.getReadLocalityMetrics();
       if (weight == 0) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1979,8 +1979,59 @@ public class FSNamesystem implements Namesystem, FSClusterStats,
         blockManager.getDatanodeManager().sortLocatedBlocks(
             clientMachine, lastBlockList);
       }
+
+      //Locations of LocatedBlocks have been sorted
+      //Measure distance to first location of all block to get a feeling of read locality within the cluster
+      for(LocatedBlock b : blocks.getLocatedBlocks()) {
+        measureDistanceToFirstLocation(clientMachine, b);
+      }
+      // lastBlock is not part of getLocatedBlocks(), so we need to check it individually
+      if (lastBlock != null) {
+        measureDistanceToFirstLocation(clientMachine, lastBlock);
+      }
     }
+
     return blocks;
+  }
+
+  private void measureDistanceToFirstLocation(String clientMachine, LocatedBlock locatedBlock) {
+    DatanodeInfo[] locs = locatedBlock.getLocations();
+    if(locs.length > 0) {
+      DatanodeInfo closerLocation = locs[0];
+      NetworkTopology networkTopology = blockManager.getDatanodeManager().getNetworkTopology();
+
+      //mimic code in DatanodeManager.sortLocatedBlocks
+      //to be able to create a Node object representing possibly an offswitch client
+      //then we can use NetworkTopology to measure the distance
+      Node client = blockManager.getDatanodeManager().getDatanodeByHost(clientMachine);
+      if (client == null) {
+        List<String> hosts = new ArrayList<String> (1);
+        hosts.add(clientMachine);
+        List<String> resolvedHosts = blockManager.getDatanodeManager().resolveNetworkLocation(hosts);
+        if (resolvedHosts != null && !resolvedHosts.isEmpty()) {
+          String rName = resolvedHosts.get(0);
+          if (rName != null) {
+            client = new NodeBase(rName + NodeBase.PATH_SEPARATOR_STR +
+                    clientMachine);
+          }
+        } else {
+          LOG.error("Node Resolution failed. Please make sure that rack " +
+                  "awareness scripts are functional.");
+        }
+      }
+
+      //client could be null due to the code above, but getWeight method accepts null first parameter
+      int weight = networkTopology.getWeight(client, closerLocation);
+      //describe in method getWeight: 0 is local, 1 is same rack, 2 is off rack
+      ReadLocalityMetrics readLocalityMetrics = NameNode.getReadLocalityMetrics();
+      if (weight == 0) {
+        readLocalityMetrics.incrHostLocalReads();
+      } else if (weight == 1) {
+        readLocalityMetrics.incrRackLocalReads();
+      } else {
+        readLocalityMetrics.incrOffSwitchReads();
+      }
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -350,6 +350,7 @@ public class NameNode implements NameNodeStatusMXBean {
 
   static NameNodeMetrics metrics;
   static BlockPlacementMetrics blockPlacementMetrics;
+  static ReadLocalityMetrics readLocalityMetrics;
   private static final StartupProgress startupProgress = new StartupProgress();
   /** Return the {@link FSNamesystem} object.
    * @return {@link FSNamesystem} object.
@@ -365,6 +366,7 @@ public class NameNode implements NameNodeStatusMXBean {
   static void initMetrics(Configuration conf, NamenodeRole role) {
     metrics = NameNodeMetrics.create(conf, role);
     blockPlacementMetrics = BlockPlacementMetrics.create(conf, role);
+    readLocalityMetrics = ReadLocalityMetrics.create(conf, role);
   }
 
   public static NameNodeMetrics getNameNodeMetrics() {
@@ -373,6 +375,10 @@ public class NameNode implements NameNodeStatusMXBean {
 
   public static BlockPlacementMetrics getBlockPlacementMetrics() {
     return blockPlacementMetrics;
+  }
+
+  public static ReadLocalityMetrics getReadLocalityMetrics() {
+    return readLocalityMetrics;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ReadLocalityMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ReadLocalityMetrics.java
@@ -17,11 +17,11 @@ import static org.apache.hadoop.metrics2.impl.MsInfo.SessionId;
 public class ReadLocalityMetrics {
     final MetricsRegistry registry = new MetricsRegistry("namenode");
 
-    @Metric("Number of placement on the same host as the writer")
+    @Metric("Number of placements on the same host as the writer")
     MutableCounterLong hostLocalReads;
-    @Metric("Number of placement on the same rack as the writer")
+    @Metric("Number of placements on the same rack as the writer")
     MutableCounterLong rackLocalReads;
-    @Metric("Number of placement on a different rack as the writer")
+    @Metric("Number of placements on a different rack as the writer")
     MutableCounterLong offSwitchReads;
 
     ReadLocalityMetrics(String processName, String sessionId) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ReadLocalityMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ReadLocalityMetrics.java
@@ -1,0 +1,55 @@
+package org.apache.hadoop.hdfs.server.namenode;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.NamenodeRole;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+
+import static org.apache.hadoop.metrics2.impl.MsInfo.ProcessName;
+import static org.apache.hadoop.metrics2.impl.MsInfo.SessionId;
+
+@Metrics(name="ReadLocality", about="ReadLocality metrics from namenode", context="dfs")
+public class ReadLocalityMetrics {
+    final MetricsRegistry registry = new MetricsRegistry("namenode");
+
+    @Metric("Number of placement on the same host as the writer")
+    MutableCounterLong hostLocalReads;
+    @Metric("Number of placement on the same rack as the writer")
+    MutableCounterLong rackLocalReads;
+    @Metric("Number of placement on a different rack as the writer")
+    MutableCounterLong offSwitchReads;
+
+    ReadLocalityMetrics(String processName, String sessionId) {
+        registry.tag(ProcessName, processName).tag(SessionId, sessionId);
+    }
+
+    public static ReadLocalityMetrics create(Configuration conf, NamenodeRole r) {
+        String sessionId = conf.get(DFSConfigKeys.DFS_METRICS_SESSION_ID_KEY);
+        String processName = r.toString();
+        MetricsSystem ms = DefaultMetricsSystem.instance();
+
+        return ms.register(new ReadLocalityMetrics(processName, sessionId));
+    }
+
+    public void shutdown() {
+        DefaultMetricsSystem.shutdown();
+    }
+
+    public void incrHostLocalReads() {
+        hostLocalReads.incr();
+    }
+
+    public void incrRackLocalReads() {
+        rackLocalReads.incr();
+    }
+
+    public void incrOffSwitchReads() {
+        offSwitchReads.incr();
+    }
+
+}


### PR DESCRIPTION
This evaluation is not perfect as DFSCLient can still chose other locations to read blocks. But that should be a good enough view of what most of the DFSClients will do when performing some reads.

The new metrics are available in the JMX page of the namenode