### PR TITLE
Allow downgrade of ResourceManager from 3.3.0 to 2.6.0

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/RMDelegationTokenIdentifier.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/RMDelegationTokenIdentifier.java
@@ -58,8 +58,7 @@ public class RMDelegationTokenIdentifier extends AbstractDelegationTokenIdentifi
 
   public static final Text KIND_NAME = new Text("RM_DELEGATION_TOKEN");
 
-  RMDelegationTokenIdentifierDataProto.Builder builder =
-          RMDelegationTokenIdentifierDataProto.newBuilder();
+  YARNDelegationTokenIdentifierProto.Builder builder = YARNDelegationTokenIdentifierProto.newBuilder();
 
   public RMDelegationTokenIdentifier() {
   }
@@ -68,33 +67,24 @@ public class RMDelegationTokenIdentifier extends AbstractDelegationTokenIdentifi
   public void readFields(DataInput in) throws IOException {
     byte[] data = IOUtils.readFullyToByteArray(in);
     try {
+      //HDP2 style
       DataInput di = new DataInputStream(new ByteArrayInputStream(data));
-      super.readFields(di);
-      //renewdate is not necessarily present, don't fail
-      try {
-        this.renewDate = di.readLong();
-      } catch (IOException e) {
-        //ignore
-      }
+      this.readFieldsOldFormat(di);
     } catch (IOException e) {
-      //failed to read in old format style, maybe this is a new proto based token
+      //HDP3 style based on proto
       builder.mergeFrom(data);
-      YARNDelegationTokenIdentifierProto tokenIdentifier = builder.getTokenIdentifier();
-      setOwner(new Text(tokenIdentifier.getOwner()));
-      setRenewer(new Text(tokenIdentifier.getRenewer()));
-      setRealUser(new Text(tokenIdentifier.getRealUser()));
-      setIssueDate(tokenIdentifier.getIssueDate());
-      setMaxDate(tokenIdentifier.getMaxDate());
-      setSequenceNumber(tokenIdentifier.getSequenceNumber());
-      setMasterKeyId(tokenIdentifier.getMasterKeyId());
-      this.renewDate = builder.getRenewDate();
+      setOwner(new Text(builder.getOwner()));
+      setRenewer(new Text(builder.getRenewer()));
+      setRealUser(new Text(builder.getRealUser()));
+      setIssueDate(builder.getIssueDate());
+      setMaxDate(builder.getMaxDate());
+      setSequenceNumber(builder.getSequenceNumber());
+      setMasterKeyId(builder.getMasterKeyId());
     }
   }
 
-  private long renewDate;
-
-  public long getRenewDate() {
-    return this.renewDate;
+  public void readFieldsOldFormat(DataInput di) throws IOException {
+    super.readFields(di);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/RMDelegationTokenIdentifier.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/RMDelegationTokenIdentifier.java
@@ -19,6 +19,9 @@
 package org.apache.hadoop.yarn.security.client;
 
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
@@ -26,6 +29,7 @@ import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.net.NetUtils;
@@ -40,6 +44,8 @@ import org.apache.hadoop.yarn.api.protocolrecords.RenewDelegationTokenRequest;
 import org.apache.hadoop.yarn.client.ClientRMProxy;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.proto.YarnSecurityTokenProtos.RMDelegationTokenIdentifierDataProto;
+import org.apache.hadoop.yarn.proto.YarnSecurityTokenProtos.YARNDelegationTokenIdentifierProto;
 import org.apache.hadoop.yarn.util.Records;
 
 /**
@@ -51,10 +57,46 @@ import org.apache.hadoop.yarn.util.Records;
 public class RMDelegationTokenIdentifier extends AbstractDelegationTokenIdentifier {
 
   public static final Text KIND_NAME = new Text("RM_DELEGATION_TOKEN");
-  
+
+  RMDelegationTokenIdentifierDataProto.Builder builder =
+          RMDelegationTokenIdentifierDataProto.newBuilder();
+
   public RMDelegationTokenIdentifier() {
   }
-  
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    byte[] data = IOUtils.readFullyToByteArray(in);
+    try {
+      DataInput di = new DataInputStream(new ByteArrayInputStream(data));
+      super.readFields(di);
+      //renewdate is not necessarily present, don't fail
+      try {
+        this.renewDate = di.readLong();
+      } catch (IOException e) {
+        //ignore
+      }
+    } catch (IOException e) {
+      //failed to read in old format style, maybe this is a new proto based token
+      builder.mergeFrom(data);
+      YARNDelegationTokenIdentifierProto tokenIdentifier = builder.getTokenIdentifier();
+      setOwner(new Text(tokenIdentifier.getOwner()));
+      setRenewer(new Text(tokenIdentifier.getRenewer()));
+      setRealUser(new Text(tokenIdentifier.getRealUser()));
+      setIssueDate(tokenIdentifier.getIssueDate());
+      setMaxDate(tokenIdentifier.getMaxDate());
+      setSequenceNumber(tokenIdentifier.getSequenceNumber());
+      setMasterKeyId(tokenIdentifier.getMasterKeyId());
+      this.renewDate = builder.getRenewDate();
+    }
+  }
+
+  private long renewDate;
+
+  public long getRenewDate() {
+    return this.renewDate;
+  }
+
   /**
    * Create a new delegation token identifier
    * @param owner the effective username of the token owner

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/RMDelegationTokenIdentifierData.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/RMDelegationTokenIdentifierData.java
@@ -1,0 +1,58 @@
+package org.apache.hadoop.yarn.security.client;
+
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.yarn.proto.YarnSecurityTokenProtos.RMDelegationTokenIdentifierDataProto;
+import org.apache.hadoop.yarn.proto.YarnSecurityTokenProtos.YARNDelegationTokenIdentifierProto;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+public class RMDelegationTokenIdentifierData {
+
+    private final RMDelegationTokenIdentifierDataProto.Builder builder =
+            RMDelegationTokenIdentifierDataProto.newBuilder();
+
+    private final RMDelegationTokenIdentifier identifier;
+    private final long renewDate;
+
+    public RMDelegationTokenIdentifierData(DataInputStream in) throws IOException {
+        //make a copy of the input stream so that it can be read many times
+        byte[] data = IOUtils.readFullyToByteArray(in);
+        RMDelegationTokenIdentifier tmpIdentifier;
+        long tmpRenewDate;
+        try {
+            //HDP2 way
+            DataInput di = new DataInputStream(new ByteArrayInputStream(data));
+            tmpIdentifier = new RMDelegationTokenIdentifier();
+            tmpIdentifier.readFieldsOldFormat(di);
+            tmpRenewDate = di.readLong();
+        } catch (IOException e) {
+            //HDP3 using proto
+            builder.mergeFrom(data);
+            YARNDelegationTokenIdentifierProto tokenIdentifier = builder.getTokenIdentifier();
+            tmpIdentifier = new RMDelegationTokenIdentifier();
+            tmpIdentifier.setOwner(new Text(tokenIdentifier.getOwner()));
+            tmpIdentifier.setRenewer(new Text(tokenIdentifier.getRenewer()));
+            tmpIdentifier.setRealUser(new Text(tokenIdentifier.getRealUser()));
+            tmpIdentifier.setIssueDate(tokenIdentifier.getIssueDate());
+            tmpIdentifier.setMaxDate(tokenIdentifier.getMaxDate());
+            tmpIdentifier.setSequenceNumber(tokenIdentifier.getSequenceNumber());
+            tmpIdentifier.setMasterKeyId(tokenIdentifier.getMasterKeyId());
+            tmpRenewDate = builder.getRenewDate();
+        }
+
+        this.identifier = tmpIdentifier;
+        this.renewDate = tmpRenewDate;
+    }
+
+    public RMDelegationTokenIdentifier getRMDelegationTokenIdentifier() {
+        return identifier;
+    }
+
+    public long getRenewDate() {
+        return renewDate;
+    }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/proto/yarn_security_token.proto
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/proto/yarn_security_token.proto
@@ -30,3 +30,18 @@ message ClientToAMTokenIdentifierProto {
   optional ApplicationAttemptIdProto appAttemptId = 1;
   optional string clientName = 2;
 }
+
+message YARNDelegationTokenIdentifierProto {
+  optional string owner = 1;
+  optional string renewer = 2;
+  optional string realUser = 3;
+  optional int64 issueDate = 4;
+  optional int64 maxDate = 5;
+  optional int32 sequenceNumber = 6;
+  optional int32 masterKeyId = 7;
+}
+
+message RMDelegationTokenIdentifierDataProto {
+  optional YARNDelegationTokenIdentifierProto token_identifier = 1;
+  optional int64 renewDate = 2;
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/proto/yarn_security_token.proto
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/proto/yarn_security_token.proto
@@ -31,6 +31,7 @@ message ClientToAMTokenIdentifierProto {
   optional string clientName = 2;
 }
 
+//used for RMDelegationToken in HDP3
 message YARNDelegationTokenIdentifierProto {
   optional string owner = 1;
   optional string renewer = 2;
@@ -41,6 +42,7 @@ message YARNDelegationTokenIdentifierProto {
   optional int32 masterKeyId = 7;
 }
 
+//used for RMZKStateStore in HDP3
 message RMDelegationTokenIdentifierDataProto {
   optional YARNDelegationTokenIdentifierProto token_identifier = 1;
   optional int64 renewDate = 2;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
@@ -558,7 +558,7 @@ public class ZKRMStateStore extends RMStateStore {
           RMDelegationTokenIdentifier identifier =
               new RMDelegationTokenIdentifier();
           identifier.readFields(fsIn);
-          long renewDate = fsIn.readLong();
+          long renewDate = identifier.getRenewDate();
           rmState.rmSecretManagerState.delegationTokenState.put(identifier,
               renewDate);
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.yarn.proto.YarnServerResourceManagerRecoveryProtos.Appl
 import org.apache.hadoop.yarn.proto.YarnServerResourceManagerRecoveryProtos.ApplicationStateDataProto;
 import org.apache.hadoop.yarn.proto.YarnServerResourceManagerRecoveryProtos.EpochProto;
 import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifier;
+import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifierData;
 import org.apache.hadoop.yarn.server.records.impl.pb.VersionPBImpl;
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.server.resourcemanager.RMZKUtils;
@@ -555,10 +556,9 @@ public class ZKRMStateStore extends RMStateStore {
 
       try {
         if (childNodeName.startsWith(DELEGATION_TOKEN_PREFIX)) {
-          RMDelegationTokenIdentifier identifier =
-              new RMDelegationTokenIdentifier();
-          identifier.readFields(fsIn);
-          long renewDate = identifier.getRenewDate();
+          RMDelegationTokenIdentifierData idData = new RMDelegationTokenIdentifierData(fsIn);
+          RMDelegationTokenIdentifier identifier = idData.getRMDelegationTokenIdentifier();
+          long renewDate = idData.getRenewDate();
           rmState.rmSecretManagerState.delegationTokenState.put(identifier,
               renewDate);
         }


### PR DESCRIPTION
RMDelegationTokens are stored with a new proto in HDP3.3, this commit allows the 2.6 RM to read such tokens