### PR TITLE
NodeManager downgrade 3.3 to 2.6

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMLeveldbStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMLeveldbStateStoreService.java
@@ -240,7 +240,7 @@ public class NMLeveldbStateStoreService extends NMStateStoreService {
         rcs.status = RecoveredContainerStatus.COMPLETED;
         rcs.exitCode = Integer.parseInt(asString(entry.getValue()));
       } else {
-        throw new IOException("Unexpected container state key: " + key);
+        LOG.warn("Unexpected key during container recovery: " + key);
       }
     }
     return rcs;


### PR DESCRIPTION
Nodemanager 3.3.0 adds a lot of new keys in the data stored in the local leveldb. This commit prevents the nodemanager to fail on restart when unknown fields are detected.
Since those new fields are not used by version 2.6 we can just ignore them.